### PR TITLE
template: don't display summary and content

### DIFF
--- a/pelican-theme/templates/archives.html
+++ b/pelican-theme/templates/archives.html
@@ -23,6 +23,10 @@
 <!-- content -->
 {{ article.content }}
 <!-- /content -->
+        {% else %}
+<!-- summary -->
+{{ article.summary|indent(10) }}
+<!-- /summary -->
         {% endif %}
         <footer>
           {% macro footer() %}{% include "article_footer.html" %}{% endmacro %}

--- a/pelican-theme/templates/archives.html
+++ b/pelican-theme/templates/archives.html
@@ -23,7 +23,7 @@
 <!-- content -->
 {{ article.content }}
 <!-- /content -->
-        {% else %}
+        {% elif article.metadata.summary is not defined %}
 <!-- summary -->
 {{ article.summary|indent(10) }}
 <!-- /summary -->

--- a/pelican-theme/templates/article_header.html
+++ b/pelican-theme/templates/article_header.html
@@ -6,5 +6,4 @@
     </time>
     {{ article.title }}
   </a></h1>
-  {{ article.summary|indent(2) }}
 </header>

--- a/pelican-theme/templates/article_header.html
+++ b/pelican-theme/templates/article_header.html
@@ -6,4 +6,5 @@
     </time>
     {{ article.title }}
   </a></h1>
+  {% if article.metadata.summary is defined %}{{ article.summary|indent(2) }}{% endif %}
 </header>

--- a/pelican-theme/templates/base_blog_section.html
+++ b/pelican-theme/templates/base_blog_section.html
@@ -18,7 +18,9 @@
       <article>
         {% macro header() %}{% include "article_header.html" %}{% endmacro %}
         {{ header()|indent(8) }}
+        {% if article.metadata.summary is not defined %}
         {{ article.summary|indent(10) }}
+        {% endif %}
         <footer>
           {% macro footer() %}{% include "article_footer.html" %}{% endmacro %}
           {{ footer()|indent(10) }}

--- a/pelican-theme/templates/base_blog_section.html
+++ b/pelican-theme/templates/base_blog_section.html
@@ -18,6 +18,7 @@
       <article>
         {% macro header() %}{% include "article_header.html" %}{% endmacro %}
         {{ header()|indent(8) }}
+        {{ article.summary|indent(10) }}
         <footer>
           {% macro footer() %}{% include "article_footer.html" %}{% endmacro %}
           {{ footer()|indent(10) }}

--- a/pelican-theme/templates/index.html
+++ b/pelican-theme/templates/index.html
@@ -23,6 +23,10 @@
 <!-- content -->
 {{ article.content }}
 <!-- /content -->
+        {% else %}
+<!-- summary -->
+{{ article.summary|indent(10) }}
+<!-- /summary -->
         {% endif %}
         <footer>
           {% macro footer() %}{% include "article_footer.html" %}{% endmacro %}

--- a/pelican-theme/templates/index.html
+++ b/pelican-theme/templates/index.html
@@ -23,7 +23,7 @@
 <!-- content -->
 {{ article.content }}
 <!-- /content -->
-        {% else %}
+        {% elif article.metadata.summary is not defined %}
 <!-- summary -->
 {{ article.summary|indent(10) }}
 <!-- /summary -->


### PR DESCRIPTION
In index pages (archive, index) the 1st commit show all its content, but
is preceded by the summary, so first lines are repeated twice.

The same happens in article.

I removed the summary part from article_header, and placed where needed in
conditional statements.