### PR TITLE
theme: let every page have its language

### DIFF
--- a/pelican-theme/templates/base.html
+++ b/pelican-theme/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ DEFAULT_LANG }}">
+<html lang="{% if page and page.lang %}{{ page.lang }}{% elif article and article.lang %}{{ article.lang }}{% else %}{{ DEFAULT_LANG }}{%endif %}">
 <head>
   {% block head %}
   <meta charset="UTF-8" />


### PR DESCRIPTION
In multi language sites, not all pages have the same language, so setting lang to DEFAULT_LANG can be misleading.