### PR TITLE
Use Python3 executable, instead of Python

### DIFF
--- a/doxygen/dox2html5.py
+++ b/doxygen/dox2html5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 #   This file is part of m.css.


### PR DESCRIPTION
macOS & Linux define the `python` executable to be Python 2.x, and since
dox2html5 does not work with Python 2.x, explicitly use the Python 3.x
executable to ensure it's working.