### PR TITLE
Fix encoding error on Windows

### DIFF
--- a/doxygen/dox2html5.py
+++ b/doxygen/dox2html5.py
@@ -2743,8 +2743,8 @@ def run(doxyfile, templates=default_templates, wildcard=default_wildcard, index_
                 **state.doxyfile)
 
             output = os.path.join(html_output, parsed.compound.url)
-            with open(output, 'w') as f:
-                f.write(rendered)
+            with open(output, 'wb') as f:
+                f.write(rendered.encode('utf-8'))
 
     # Empty index page in case no mainpage documentation was provided so
     # there's at least some entrypoint. Doxygen version is not set in this


### PR DESCRIPTION
I was using some ASCII art in my .dox pages (using the output of `tree`), and the following error happened when I tried to build it on Windows:

```
Traceback (most recent call last):
  File "C:\Users\leandros\p4\depot\extern\bin\shared\m.css\doxygen\dox2html5.py", line 2794, in <module>
    run(doxyfile, os.path.abspath(args.templates), args.wildcard, args.index_pages, search_merge_subtrees=not args.search_no_subtree_merging, search_add_lookahead_barriers=not args.search_no_lookahead_barriers, search_merge_prefixes=not args.search_no_prefix_merging)
  File "C:\Users\leandros\p4\depot\extern\bin\shared\m.css\doxygen\dox2html5.py", line 2723, in run
    f.write(rendered)
  File "C:\Users\leandros\p4\depot\extern\bin\win64\Python36\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 3594-3596: character maps to <undefined>
```

If you think about it, it's obvious: Windows doesn't default to UTF-8, but to some other, ancient, codepage, which does not support said characters. 
Fixed this, by explicitly using utf-8 in the output. Any browser & operating system will read this just fine, including Windows.