### PR TITLE
[WIP?] Graphviz/dot: support node and edge links

### DIFF
--- a/pelican-plugins/dot2svg.py
+++ b/pelican-plugins/dot2svg.py
@@ -43,9 +43,19 @@ _comment_src = re.compile(r"""<!--[^-]+-->\n""")
 # and <title>
 _class_src = re.compile(r"""<g id="(edge|node)\d+" class="(?P<type>edge|node)(?P<classes>[^"]*)">[\n]?<title>(?P<title>[^<]*)</title>
 <(?P<element>ellipse|polygon|path) fill="(?P<fill>[^"]+)" stroke="[^"]+" """)
-
 _class_dst = r"""<g class="{classes}">
 <title>{title}</title>
+<{element} """
+
+# Nodes that are links have an additional group containing a link inside. Again
+# Graphviz < 2.40 (Ubuntu 16.04 and older) doesn't have a linebreak between <g>
+# and <title>.
+_class_with_link_inside_src = re.compile(r"""<g id="(edge|node)\d+" class="(?P<type>edge|node)(?P<classes>[^"]*)">[\n]?<title>(?P<title>[^<]*)</title>
+<g id="a_(edge|node)\d+"><a (?P<link>[^>]+)>
+<(?P<element>ellipse|polygon|path) fill="(?P<fill>[^"]+)" stroke="[^"]+" """)
+_class_with_link_inside_dst = r"""<g class="{classes}">
+<title>{title}</title>
+<g><a {link}>
 <{element} """
 
 _attributes_src = re.compile(r"""<(?P<element>ellipse|polygon|polyline) fill="[^"]+" stroke="[^"]+" """)
@@ -107,6 +117,20 @@ def dot2svg(source, size=None, attribs=''):
             title=match.group('title'),
             element=match.group('element'))
     svg = _class_src.sub(element_repl, svg)
+
+    # Links have additional group around, second pass with a different regex
+    def element_link_repl(match):
+        classes = ['m-' + match.group('type')] + match.group('classes').replace('&#45;', '-').split()
+        # distinguish between solid and filled nodes
+        if match.group('type') == 'node' and match.group('fill') == 'none':
+            classes += ['m-flat']
+
+        return _class_with_link_inside_dst.format(
+            link=match.group('link'),
+            classes=' '.join(classes),
+            title=match.group('title'),
+            element=match.group('element'))
+    svg = _class_with_link_inside_src.sub(element_link_repl, svg)
 
     # Remove unnecessary fill and stroke attributes
     svg = _attributes_src.sub(_attributes_dst, svg)

--- a/pelican-plugins/m/test/dot/page.html
+++ b/pelican-plugins/m/test/dot/page.html
@@ -200,6 +200,42 @@ and the arrowheads, nothing else. Non-default font size should be preserved.</p>
 </g>
 </svg>
 </div>
+<p>Links:</p>
+<div class="m-graph">
+<svg style="width: 10.438rem; height: 8.500rem;" viewBox="0.00 0.00 167.40 135.54">
+<g transform="scale(1 1) rotate(0) translate(4 131.5391)">
+<g class="m-node m-primary">
+<title>A</title>
+<g><a xlink:href="#" xlink:title="link to #">
+<ellipse cx="59.397" cy="-109.1543" rx="59.2941" ry="18.2703"/>
+<text text-anchor="middle" x="59.397" y="-105.3543">link to #</text>
+</a>
+</g>
+</g>
+<g class="m-node m-success m-flat">
+<title>B</title>
+<g><a xlink:href="#" xlink:title="link to /">
+<ellipse cx="59.397" cy="-18.3848" rx="53.9813" ry="18.2703"/>
+<text text-anchor="middle" x="59.397" y="-14.5848">link to /</text>
+</a>
+</g>
+</g>
+<g class="m-edge m-warning">
+<title>A&#45;&gt;B</title>
+<g><a xlink:href="http://mcss.mosra.cz/" xlink:title="link to m.css">
+<path d="M59.397,-90.3468C59.397,-77.8501 59.397,-61.2025 59.397,-47.0671"/>
+<polygon points="62.8971,-46.8576 59.397,-36.8576 55.8971,-46.8577 62.8971,-46.8576"/>
+</a>
+</g>
+<g id="a_edge1&#45;label"><a xlink:href="http://mcss.mosra.cz/" xlink:title="link to m.css">
+<text text-anchor="middle" x="109.397" y="-59.9696">link to m.css</text>
+</a>
+</g>
+</g>
+</g>
+</svg>
+</div>
+<p>Figures:</p>
 <figure class="m-figure">
 <svg class="m-graph m-info" style="width: 3.875rem; height: 7.375rem;" viewBox="0.00 0.00 62.00 117.54">
 <g transform="scale(1 1) rotate(0) translate(4 113.5391)">

--- a/pelican-plugins/m/test/dot/page.rst
+++ b/pelican-plugins/m/test/dot/page.rst
@@ -55,6 +55,17 @@ Structs:
 
     another [label="a | { b | c } | d | e" shape=record]
 
+Links:
+
+.. digraph::
+
+    A [label="link to #" URL="#" style=filled class="m-primary"]
+    B [label="link to /" URL="#" class="m-success"]
+
+    A -> B [label="link to m.css" URL="http://mcss.mosra.cz/" class="m-warning"]
+
+Figures:
+
 .. graph-figure:: This is a title.
 
     .. digraph:: A to B


### PR DESCRIPTION
This again turned out to be way more time consuming than expected and I need to do other things right now, so postponing until I have time again. Things to do:

- [x] A separate regex that matches nodes and edges with links and converts them to CSS classes that m.css understand
- [ ] There's a separate `<g id="a_edge1&#45;label">` for the edge label which should be removed and replaced with just `<g>`
- [ ] Update test files for graphviz 2:36 and 2.38 (ugh)
- [ ] Doxygen XML output doesn't properly replace `\ref`s with links, even though [it does so for HTML output](https://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmddot). Yet another pointless annoying unnecessary difference with the XML output, need to submit a PR to doxygen to fix this. **Ugh.**

A workaround for now, until the above is done, could be:

- don't use node/edge links (heh)
- or apply this half-done PR locally and hardcode the URLs (eww)

Cc: @jbakosi