### PR TITLE
Doxygen IMAGE_PATH variable support

### DIFF
--- a/doc/doxygen.rst
+++ b/doc/doxygen.rst
@@ -283,6 +283,9 @@ Variable                        Description
                                 searched relative to the Doxyfile base dir and
                                 to the ``dox2html5.py`` script dir as a
                                 fallback.
+:ini:`IMAGE_PATH`               Extra diretories in which the image file are
+                                searched. See `Images and figures`_ for more
+                                information.
 :ini:`DOT_FONTNAME`             Font name to use for ``@dot`` and ``@dotfile``
                                 commands. To ensure consistent look with the
                                 default m.css themes, set it to
@@ -591,7 +594,13 @@ single-paragraph item will make sure the enclosing :html:`<p>` is not stripped.
 ---------------------
 
 To match the stock HTML output, images that are marked with ``html`` target are
-used. If image name is present, the image is rendered as a figure with caption.
+used. Image files are searched in the following order:
+
+1.  XML output directory
+2.  same directory as Doxyfile exists
+3.  ``IMAGE_PATH`` tag in the Doxyfile
+
+If image name is present, the image is rendered as a figure with caption.
 It's possible affect width/height of the image using the ``sizespec`` parameter
 (unlike stock Doxygen, which makes use of this field only for LaTeX output and
 ignores it for HTML output). The parameter is converted to an inline CSS

--- a/doxygen/dox2html5.py
+++ b/doxygen/dox2html5.py
@@ -1042,7 +1042,7 @@ def parse_desc_internal(state: State, element: ET.Element, immediate_parent: ET.
             # can be in <para> but often also in <div> and other m.css-specific
             # elements
             has_block_elements = True
-            image_path = state.doxyfile.get('IMAGE_PATH', '')
+            image_path = state.doxyfile.get('IMAGE_PATH', [])
 
             name = i.attrib['name']
             if i.attrib['type'] == 'html':
@@ -1050,11 +1050,11 @@ def parse_desc_internal(state: State, element: ET.Element, immediate_parent: ET.
                     os.path.join(state.basedir, state.doxyfile['OUTPUT_DIRECTORY'], state.doxyfile['XML_OUTPUT'], name),
                     os.path.join(state.basedir, name)
                 ]
-                if image_path:
-                    if os.path.isabs(image_path):
-                        path_candidates.append(os.path.join(image_path, name))
+                for path in image_path:
+                    if os.path.isabs(path):
+                        path_candidates.append(os.path.join(path, name))
                     else:
-                        path_candidates.append(os.path.join(state.basedir, image_path, name))
+                        path_candidates.append(os.path.join(state.basedir, path, name))
 
                 image_found = False
                 for path in path_candidates:
@@ -1063,7 +1063,7 @@ def parse_desc_internal(state: State, element: ET.Element, immediate_parent: ET.
                         image_found = True
                         break
 
-                if image_found:
+                if not image_found:
                     logging.warning("{}: image {} was not found in XML_OUTPUT".format(state.current, name))
 
                 sizespec = ''
@@ -2900,7 +2900,7 @@ def parse_doxyfile(state: State, doxyfile, config = None):
         'HTML_EXTRA_FILES': [],
         'DOT_FONTNAME': ['Helvetica'],
         'DOT_FONTSIZE': ['10'],
-        'IMAGE_PATH': [''],
+        'IMAGE_PATH': [],
 
         'M_CLASS_TREE_EXPAND_LEVELS': ['1'],
         'M_FILE_TREE_EXPAND_LEVELS': ['1'],
@@ -3012,7 +3012,6 @@ list using <span class="m-label m-dim">&darr;</span> and
               'HTML_OUTPUT',
               'XML_OUTPUT',
               'DOT_FONTNAME',
-              'IMAGE_PATH',
               'M_MAIN_PROJECT_URL',
               'M_HTML_HEADER',
               'M_PAGE_HEADER',
@@ -3042,6 +3041,7 @@ list using <span class="m-label m-dim">&darr;</span> and
     for i in ['TAGFILES',
               'HTML_EXTRA_STYLESHEET',
               'HTML_EXTRA_FILES',
+              'IMAGE_PATH',
               'M_LINKS_NAVBAR1',
               'M_LINKS_NAVBAR2']:
         if i in config:

--- a/doxygen/dox2html5.py
+++ b/doxygen/dox2html5.py
@@ -1051,7 +1051,10 @@ def parse_desc_internal(state: State, element: ET.Element, immediate_parent: ET.
                     os.path.join(state.basedir, name)
                 ]
                 if image_path:
-                    path_candidates.append(os.path.join(image_path, name))
+                    if os.path.isabs(image_path):
+                        path_candidates.append(os.path.join(image_path, name))
+                    else:
+                        path_candidates.append(os.path.join(state.basedir, image_path, name))
 
                 image_found = False
                 for path in path_candidates:

--- a/doxygen/dox2html5.py
+++ b/doxygen/dox2html5.py
@@ -1042,13 +1042,25 @@ def parse_desc_internal(state: State, element: ET.Element, immediate_parent: ET.
             # can be in <para> but often also in <div> and other m.css-specific
             # elements
             has_block_elements = True
+            image_path = state.doxyfile.get('IMAGE_PATH', '')
 
             name = i.attrib['name']
             if i.attrib['type'] == 'html':
-                path = os.path.join(state.basedir, state.doxyfile['OUTPUT_DIRECTORY'], state.doxyfile['XML_OUTPUT'], name)
-                if os.path.exists(path):
-                    state.images += [path]
-                else:
+                path_candidates = [
+                    os.path.join(state.basedir, state.doxyfile['OUTPUT_DIRECTORY'], state.doxyfile['XML_OUTPUT'], name),
+                    os.path.join(state.basedir, name)
+                ]
+                if image_path:
+                    path_candidates.append(os.path.join(image_path, name))
+
+                image_found = False
+                for path in path_candidates:
+                    if os.path.exists(path):
+                        state.images += [path]
+                        image_found = True
+                        break
+
+                if image_found:
                     logging.warning("{}: image {} was not found in XML_OUTPUT".format(state.current, name))
 
                 sizespec = ''
@@ -2885,6 +2897,7 @@ def parse_doxyfile(state: State, doxyfile, config = None):
         'HTML_EXTRA_FILES': [],
         'DOT_FONTNAME': ['Helvetica'],
         'DOT_FONTSIZE': ['10'],
+        'IMAGE_PATH': [''],
 
         'M_CLASS_TREE_EXPAND_LEVELS': ['1'],
         'M_FILE_TREE_EXPAND_LEVELS': ['1'],
@@ -2996,6 +3009,7 @@ list using <span class="m-label m-dim">&darr;</span> and
               'HTML_OUTPUT',
               'XML_OUTPUT',
               'DOT_FONTNAME',
+              'IMAGE_PATH',
               'M_MAIN_PROJECT_URL',
               'M_HTML_HEADER',
               'M_PAGE_HEADER',

--- a/doxygen/test/test_doxyfile.py
+++ b/doxygen/test/test_doxyfile.py
@@ -70,7 +70,8 @@ list using <span class="m-label m-dim">&darr;</span> and
             'OUTPUT_DIRECTORY': '',
             'PROJECT_BRIEF': 'is cool',
             'PROJECT_NAME': 'My Pet Project',
-            'XML_OUTPUT': 'xml'
+            'XML_OUTPUT': 'xml',
+            'IMAGE_PATH': ''
         })
 
     def test_subdirs(self):

--- a/doxygen/test/test_doxyfile.py
+++ b/doxygen/test/test_doxyfile.py
@@ -71,7 +71,7 @@ list using <span class="m-label m-dim">&darr;</span> and
             'PROJECT_BRIEF': 'is cool',
             'PROJECT_NAME': 'My Pet Project',
             'XML_OUTPUT': 'xml',
-            'IMAGE_PATH': ''
+            'IMAGE_PATH': []
         })
 
     def test_subdirs(self):


### PR DESCRIPTION
# Background

[IMAGE_PATH tag](https://www.stack.nl/~dimitri/doxygen/manual/config.html#cfg_image_path) in Doxyfile is used to specify the directories which contain image files. However, m.css ignores this value and search image file only inside the XML output directory.

That directory will be generated after running `dox2html5.py`, so you can not find the image at the first time.

# What will be changed

Getting the value of `IMAGE_PATH` from Doxyfile, m.css can search image along all candidates and copy it to the destination folder.

Now, m.css search the source image in the following order

- XML output directory (default: `${OUTPUT_DIRECTORY}/xml`)
- same directory as Doxyfile exists
- `IMAGE_PATH` variable

If image file was not found in any path, the program behaves in the same way as before.

# Checklist

- [x] My code follows the guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules