### PR TITLE
[WIP] Infomation about which header to include for using class

### DIFF
--- a/doxygen/dox2html5.py
+++ b/doxygen/dox2html5.py
@@ -1877,8 +1877,14 @@ def extract_metadata(state: State, xml):
     # file location
     compound.location_file = None
     compound.location_bodyfile = None
+    compound.location_url = None
     if not compound.kind in ['dir', 'page', 'group']:
         location_tag = compounddef.find('location')
+        includes_tag = compounddef.find('includes')
+        if includes_tag is not None:
+            compound.location_bodyfile = includes_tag.text
+            if 'refid' in includes_tag.keys():
+                compound.location_url = includes_tag.attrib['refid'] + '.html'
         if location_tag is not None:
             if 'file' in location_tag.keys():
                 location_file = location_tag.attrib['file']
@@ -2691,7 +2697,16 @@ def parse_xml(state: State, xml: str):
         id = compounddef.attrib['id']
         symbol = state.compounds[id]
 
-        if symbol.location_bodyfile is not None:
+        if symbol.location_url is not None:
+            assert symbol.location_url != ''
+            refid = symbol.location_url[:-5]
+            if refid in state.compounds.keys():
+                other_compound = state.compounds[refid]
+                compound.location_bodyfile = other_compound.location_file
+                if getattr(other_compound, 'kind', '') == 'file' and other_compound.has_details and other_compound.location_file != '':
+                    compound.location_url = symbol.location_url
+
+        elif symbol.location_bodyfile is not None:
             assert symbol.location_bodyfile != ''
             compound.location_bodyfile = symbol.location_bodyfile
 

--- a/doxygen/dox2html5.py
+++ b/doxygen/dox2html5.py
@@ -2696,7 +2696,8 @@ def parse_xml(state: State, xml: str):
             compound.location_bodyfile = symbol.location_bodyfile
 
             for other_compound in state.compounds.values():
-                if getattr(other_compound, 'kind', '') == 'file' and other_compound.location_file == symbol.location_bodyfile:
+                # create a link when source file is documented
+                if getattr(other_compound, 'kind', '') == 'file' and other_compound.location_file == symbol.location_bodyfile and other_compound.has_details:
                     compound.location_url = other_compound.url
                     break
 

--- a/doxygen/templates/base-class-reference.html
+++ b/doxygen/templates/base-class-reference.html
@@ -17,11 +17,11 @@
 
 {% block main %}
         {% if compound.location_bodyfile %}
-          <p class="m-text-right">
+          <p class="m-text-right m-code">
           {% if compound.location_url %}
-            <span class="m-text m-dim">Defined in </span><a href="{{ compound.location_url }}">&lt;{{ compound.location_bodyfile }}&gt;</a>
+            <span class="cp">#include</span> <a class="cpf" href="{{ compound.location_url }}">&lt;{{ compound.location_bodyfile }}&gt;</a>
           {% else %}
-          <span class="m-text m-dim">Defined in &lt;{{ compound.location_bodyfile }}&gt;</span>
+            <span class="cp">#include</span> <span class="cpf">&lt;{{ compound.location_bodyfile }}&gt;</span>
           {% endif %}
           </p>
         {% endif %}

--- a/doxygen/templates/base-class-reference.html
+++ b/doxygen/templates/base-class-reference.html
@@ -16,6 +16,15 @@
 {% block title %}{% set j = joiner('::') %}{% for name, _ in compound.breadcrumb %}{{ j() }}{{ name }}{% endfor %} {{ compound.kind }} | {{ super() }}{% endblock %}
 
 {% block main %}
+        {% if compound.location_bodyfile %}
+          <p class="m-text-right">
+          {% if compound.location_url %}
+            <span class="m-text m-dim">Defined in </span><a href="{{ compound.location_url }}">&lt;{{ compound.location_bodyfile }}&gt;</a>
+          {% else %}
+          <span class="m-text m-dim">Defined in &lt;{{ compound.location_bodyfile }}&gt;</span>
+          {% endif %}
+          </p>
+        {% endif %}
         <h1>
           {% if compound.templates != None %}
           {% set j = joiner(', ') %}

--- a/doxygen/test/compound_deprecated/structDeprecatedNamespace_1_1BaseDeprecatedClass.html
+++ b/doxygen/test/compound_deprecated/structDeprecatedNamespace_1_1BaseDeprecatedClass.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="DeprecatedFile_8h.html">&lt;Dir/DeprecatedFile.h&gt;</a>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <a class="cpf" href="DeprecatedFile_8h.html">&lt;Dir/DeprecatedFile.h&gt;</a>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceDeprecatedNamespace.html">DeprecatedNamespace</a>::<wbr/></span>BaseDeprecatedClass <span class="m-thin">struct</span>

--- a/doxygen/test/compound_deprecated/structDeprecatedNamespace_1_1BaseDeprecatedClass.html
+++ b/doxygen/test/compound_deprecated/structDeprecatedNamespace_1_1BaseDeprecatedClass.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="DeprecatedFile_8h.html">&lt;Dir/DeprecatedFile.h&gt;</a>
+          </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceDeprecatedNamespace.html">DeprecatedNamespace</a>::<wbr/></span>BaseDeprecatedClass <span class="m-thin">struct</span>
         </h1>

--- a/doxygen/test/compound_deprecated/structDeprecatedNamespace_1_1DeprecatedClass.html
+++ b/doxygen/test/compound_deprecated/structDeprecatedNamespace_1_1DeprecatedClass.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="DeprecatedFile_8h.html">&lt;Dir/DeprecatedFile.h&gt;</a>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <a class="cpf" href="DeprecatedFile_8h.html">&lt;Dir/DeprecatedFile.h&gt;</a>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceDeprecatedNamespace.html">DeprecatedNamespace</a>::<wbr/></span>DeprecatedClass <span class="m-thin">struct</span>

--- a/doxygen/test/compound_deprecated/structDeprecatedNamespace_1_1DeprecatedClass.html
+++ b/doxygen/test/compound_deprecated/structDeprecatedNamespace_1_1DeprecatedClass.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="DeprecatedFile_8h.html">&lt;Dir/DeprecatedFile.h&gt;</a>
+          </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceDeprecatedNamespace.html">DeprecatedNamespace</a>::<wbr/></span>DeprecatedClass <span class="m-thin">struct</span>
         </h1>

--- a/doxygen/test/compound_detailed/structTemplate.html
+++ b/doxygen/test/compound_detailed/structTemplate.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <a class="cpf" href="File_8h.html">&lt;File.h&gt;</a>
           </p>
         <h1>
           <div class="m-dox-template">template&lt;class T, class U = void, class = int&gt;</div>

--- a/doxygen/test/compound_detailed/structTemplate.html
+++ b/doxygen/test/compound_detailed/structTemplate.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          </p>
         <h1>
           <div class="m-dox-template">template&lt;class T, class U = void, class = int&gt;</div>
           Template <span class="m-thin">struct</span>

--- a/doxygen/test/compound_detailed/structTemplateWarning.html
+++ b/doxygen/test/compound_detailed/structTemplateWarning.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <a class="cpf" href="File_8h.html">&lt;File.h&gt;</a>
           </p>
         <h1>
           <div class="m-dox-template">template&lt;class T&gt;</div>

--- a/doxygen/test/compound_detailed/structTemplateWarning.html
+++ b/doxygen/test/compound_detailed/structTemplateWarning.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          </p>
         <h1>
           <div class="m-dox-template">template&lt;class T&gt;</div>
           TemplateWarning <span class="m-thin">struct</span>

--- a/doxygen/test/compound_detailed/structTemplate_3_01void_01_4.html
+++ b/doxygen/test/compound_detailed/structTemplate_3_01void_01_4.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <a class="cpf" href="File_8h.html">&lt;File.h&gt;</a>
           </p>
         <h1>
           <div class="m-dox-template">template&lt;&gt;</div>

--- a/doxygen/test/compound_detailed/structTemplate_3_01void_01_4.html
+++ b/doxygen/test/compound_detailed/structTemplate_3_01void_01_4.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          </p>
         <h1>
           <div class="m-dox-template">template&lt;&gt;</div>
           Template&lt;void&gt; <span class="m-thin">struct</span>

--- a/doxygen/test/compound_filename_case/class_u_p_p_e_r_c_l_a_s_s.html
+++ b/doxygen/test/compound_filename_case/class_u_p_p_e_r_c_l_a_s_s.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          </p>
         <h1>
           UPPERCLASS <span class="m-thin">class</span>
         </h1>

--- a/doxygen/test/compound_filename_case/class_u_p_p_e_r_c_l_a_s_s.html
+++ b/doxygen/test/compound_filename_case/class_u_p_p_e_r_c_l_a_s_s.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <span class="cpf">&lt;input.h&gt;</span>
           </p>
         <h1>
           UPPERCLASS <span class="m-thin">class</span>

--- a/doxygen/test/compound_filename_case/class_u_p_p_e_r_c_l_a_s_s.html
+++ b/doxygen/test/compound_filename_case/class_u_p_p_e_r_c_l_a_s_s.html
@@ -20,7 +20,7 @@
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
           <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
           </p>
         <h1>
           UPPERCLASS <span class="m-thin">class</span>

--- a/doxygen/test/compound_listing/classRoot_1_1Directory_1_1Sub_1_1Class.html
+++ b/doxygen/test/compound_listing/classRoot_1_1Directory_1_1Sub_1_1Class.html
@@ -35,6 +35,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="Class_8h.html">&lt;Directory/Sub/Class.h&gt;</a>
+          </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceRoot.html">Root</a>::<wbr/></span><span class="m-breadcrumb"><a href="namespaceRoot_1_1Directory.html">Directory</a>::<wbr/></span><span class="m-breadcrumb"><a href="namespaceRoot_1_1Directory_1_1Sub.html">Sub</a>::<wbr/></span>Class <span class="m-thin">class</span>
         </h1>

--- a/doxygen/test/compound_listing/classRoot_1_1Directory_1_1Sub_1_1Class.html
+++ b/doxygen/test/compound_listing/classRoot_1_1Directory_1_1Sub_1_1Class.html
@@ -35,8 +35,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="Class_8h.html">&lt;Directory/Sub/Class.h&gt;</a>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <a class="cpf" href="Class_8h.html">&lt;Directory/Sub/Class.h&gt;</a>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceRoot.html">Root</a>::<wbr/></span><span class="m-breadcrumb"><a href="namespaceRoot_1_1Directory.html">Directory</a>::<wbr/></span><span class="m-breadcrumb"><a href="namespaceRoot_1_1Directory_1_1Sub.html">Sub</a>::<wbr/></span>Class <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classAnother_1_1ProtectedBase.html
+++ b/doxygen/test/cpp_derived/classAnother_1_1ProtectedBase.html
@@ -20,7 +20,7 @@
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
           <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceAnother.html">Another</a>::<wbr/></span>ProtectedBase <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classAnother_1_1ProtectedBase.html
+++ b/doxygen/test/cpp_derived/classAnother_1_1ProtectedBase.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <span class="cpf">&lt;input.h&gt;</span>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceAnother.html">Another</a>::<wbr/></span>ProtectedBase <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classAnother_1_1ProtectedBase.html
+++ b/doxygen/test/cpp_derived/classAnother_1_1ProtectedBase.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceAnother.html">Another</a>::<wbr/></span>ProtectedBase <span class="m-thin">class</span>
         </h1>

--- a/doxygen/test/cpp_derived/classBaseOutsideANamespace.html
+++ b/doxygen/test/cpp_derived/classBaseOutsideANamespace.html
@@ -20,7 +20,7 @@
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
           <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
           </p>
         <h1>
           BaseOutsideANamespace <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classBaseOutsideANamespace.html
+++ b/doxygen/test/cpp_derived/classBaseOutsideANamespace.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          </p>
         <h1>
           BaseOutsideANamespace <span class="m-thin">class</span>
         </h1>

--- a/doxygen/test/cpp_derived/classBaseOutsideANamespace.html
+++ b/doxygen/test/cpp_derived/classBaseOutsideANamespace.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <span class="cpf">&lt;input.h&gt;</span>
           </p>
         <h1>
           BaseOutsideANamespace <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classDerivedOutsideANamespace.html
+++ b/doxygen/test/cpp_derived/classDerivedOutsideANamespace.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <span class="cpf">&lt;input.h&gt;</span>
           </p>
         <h1>
           DerivedOutsideANamespace <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classDerivedOutsideANamespace.html
+++ b/doxygen/test/cpp_derived/classDerivedOutsideANamespace.html
@@ -20,7 +20,7 @@
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
           <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
           </p>
         <h1>
           DerivedOutsideANamespace <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classDerivedOutsideANamespace.html
+++ b/doxygen/test/cpp_derived/classDerivedOutsideANamespace.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          </p>
         <h1>
           DerivedOutsideANamespace <span class="m-thin">class</span>
         </h1>

--- a/doxygen/test/cpp_derived/classNamespace_1_1A.html
+++ b/doxygen/test/cpp_derived/classNamespace_1_1A.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceNamespace.html">Namespace</a>::<wbr/></span>A <span class="m-thin">class</span>
         </h1>

--- a/doxygen/test/cpp_derived/classNamespace_1_1A.html
+++ b/doxygen/test/cpp_derived/classNamespace_1_1A.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <span class="cpf">&lt;input.h&gt;</span>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceNamespace.html">Namespace</a>::<wbr/></span>A <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classNamespace_1_1A.html
+++ b/doxygen/test/cpp_derived/classNamespace_1_1A.html
@@ -20,7 +20,7 @@
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
           <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceNamespace.html">Namespace</a>::<wbr/></span>A <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classNamespace_1_1PrivateBase.html
+++ b/doxygen/test/cpp_derived/classNamespace_1_1PrivateBase.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceNamespace.html">Namespace</a>::<wbr/></span>PrivateBase <span class="m-thin">class</span>
         </h1>

--- a/doxygen/test/cpp_derived/classNamespace_1_1PrivateBase.html
+++ b/doxygen/test/cpp_derived/classNamespace_1_1PrivateBase.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <span class="cpf">&lt;input.h&gt;</span>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceNamespace.html">Namespace</a>::<wbr/></span>PrivateBase <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classNamespace_1_1PrivateBase.html
+++ b/doxygen/test/cpp_derived/classNamespace_1_1PrivateBase.html
@@ -20,7 +20,7 @@
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
           <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceNamespace.html">Namespace</a>::<wbr/></span>PrivateBase <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classNamespace_1_1VirtualBase.html
+++ b/doxygen/test/cpp_derived/classNamespace_1_1VirtualBase.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <span class="cpf">&lt;input.h&gt;</span>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceNamespace.html">Namespace</a>::<wbr/></span>VirtualBase <span class="m-thin">class</span>

--- a/doxygen/test/cpp_derived/classNamespace_1_1VirtualBase.html
+++ b/doxygen/test/cpp_derived/classNamespace_1_1VirtualBase.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceNamespace.html">Namespace</a>::<wbr/></span>VirtualBase <span class="m-thin">class</span>
         </h1>

--- a/doxygen/test/cpp_derived/classNamespace_1_1VirtualBase.html
+++ b/doxygen/test/cpp_derived/classNamespace_1_1VirtualBase.html
@@ -20,7 +20,7 @@
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
           <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="input_8h.html">&lt;input.h&gt;</a>
+          <span class="m-text m-dim">Defined in &lt;input.h&gt;</span>
           </p>
         <h1>
           <span class="m-breadcrumb"><a href="namespaceNamespace.html">Namespace</a>::<wbr/></span>VirtualBase <span class="m-thin">class</span>

--- a/doxygen/test/cpp_friends/classClass.html
+++ b/doxygen/test/cpp_friends/classClass.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <a class="cpf" href="File_8h.html">&lt;File.h&gt;</a>
           </p>
         <h1>
           Class <span class="m-thin">class</span>

--- a/doxygen/test/cpp_friends/classClass.html
+++ b/doxygen/test/cpp_friends/classClass.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          </p>
         <h1>
           Class <span class="m-thin">class</span>
         </h1>

--- a/doxygen/test/cpp_friends/classTemplate.html
+++ b/doxygen/test/cpp_friends/classTemplate.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <a class="cpf" href="File_8h.html">&lt;File.h&gt;</a>
           </p>
         <h1>
           <div class="m-dox-template">template&lt;class T, class U = void, class = int&gt;</div>

--- a/doxygen/test/cpp_friends/classTemplate.html
+++ b/doxygen/test/cpp_friends/classTemplate.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          </p>
         <h1>
           <div class="m-dox-template">template&lt;class T, class U = void, class = int&gt;</div>
           Template <span class="m-thin">class</span>

--- a/doxygen/test/cpp_signals_slots/classClass.html
+++ b/doxygen/test/cpp_signals_slots/classClass.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <a class="cpf" href="File_8h.html">&lt;File.h&gt;</a>
           </p>
         <h1>
           Class <span class="m-thin">class</span>

--- a/doxygen/test/cpp_signals_slots/classClass.html
+++ b/doxygen/test/cpp_signals_slots/classClass.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          </p>
         <h1>
           Class <span class="m-thin">class</span>
         </h1>

--- a/doxygen/test/cpp_template_alias/structTemplate.html
+++ b/doxygen/test/cpp_template_alias/structTemplate.html
@@ -19,8 +19,8 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-          <p class="m-text-right">
-            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          <p class="m-text-right m-code">
+            <span class="cp">#include</span> <a class="cpf" href="File_8h.html">&lt;File.h&gt;</a>
           </p>
         <h1>
           <div class="m-dox-template">template&lt;class T, class U = void, class = int&gt;</div>

--- a/doxygen/test/cpp_template_alias/structTemplate.html
+++ b/doxygen/test/cpp_template_alias/structTemplate.html
@@ -19,6 +19,9 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
+          <p class="m-text-right">
+            <span class="m-text m-dim">Defined in </span><a href="File_8h.html">&lt;File.h&gt;</a>
+          </p>
         <h1>
           <div class="m-dox-template">template&lt;class T, class U = void, class = int&gt;</div>
           Template <span class="m-thin">struct</span>


### PR DESCRIPTION
Part of [Important TODO](https://github.com/mosra/m.css/projects/5#card-6039499).

# Background

Doxygen html output displays the header file which defines the class body.

![test5_test5_myclass_tp_class_template_reference_-_2018-10-16_22 35 20](https://user-images.githubusercontent.com/38746469/47020650-ce38e400-d194-11e8-89a5-0cbe3d95dd42.png)

However m.css doesn't hold the information about the source file, and then cannot display what file you should include.

# What will be changed

Extracting the `file` and `bodyfile` key in the location tag, each compounds hold the information about the source file location.

Also, utilizing the `bodyfile` value, class documentation can display while header to include for using the class. If the source file is documented, m.css create a link to the file.

![mcss_example_myclass_class_mcss_example_doc_-_2018-10-16_22 22 38](https://user-images.githubusercontent.com/38746469/47020675-dbee6980-d194-11e8-849b-77906818a3e2.png)