### PR TITLE
Fix to avoid empty pages

### DIFF
--- a/documentation/doxygen.py
+++ b/documentation/doxygen.py
@@ -2384,9 +2384,9 @@ def extract_metadata(state: State, xml):
     # This is similar to compound.url_base handling in parse_xml() below.
     compound.url = 'index.html' if compound.kind == 'page' and compound.id == 'indexpage' else compound.id + '.html'
     compound.brief = parse_desc(state, compounddef.find('briefdescription'))
-    # Groups and pages are explicitly created so they *have details*, other
+    # Groups are explicitly created so they *have details*, other
     # things need to have at least some documentation
-    compound.has_details = compound.kind in ['group', 'page'] or compound.brief or compounddef.find('detaileddescription')
+    compound.has_details = compound.kind == 'group' or compound.brief or compounddef.find('detaileddescription')
     compound.children = []
 
     # Deprecation status
@@ -2684,9 +2684,9 @@ def parse_xml(state: State, xml: str):
     if state.doxyfile['M_SHOW_UNDOCUMENTED']:
         _document_all_stuff(compounddef)
 
-    # Ignoring compounds w/o any description, except for pages and groups,
+    # Ignoring compounds w/o any description, except for groups,
     # which are created explicitly
-    if not compounddef.find('briefdescription') and not compounddef.find('detaileddescription') and not compounddef.attrib['kind'] in ['page', 'group']:
+    if not compounddef.find('briefdescription') and not compounddef.find('detaileddescription') and not compounddef.attrib['kind'] == 'group':
         logging.debug("{}: neither brief nor detailed description present, skipping".format(state.current))
         return None
 

--- a/documentation/test_doxygen/page_empty_page/Doxyfile
+++ b/documentation/test_doxygen/page_empty_page/Doxyfile
@@ -1,0 +1,13 @@
+INPUT                   = input.h input.md
+QUIET                   = YES
+GENERATE_HTML           = NO
+GENERATE_LATEX          = NO
+GENERATE_XML            = YES
+XML_PROGRAMLISTING      = NO
+
+##! M_PAGE_FINE_PRINT   =
+##! M_THEME_COLOR       =
+##! M_FAVICON           =
+##! M_LINKS_NAVBAR1     =
+##! M_LINKS_NAVBAR2     =
+##! M_SEARCH_DISABLED   = YES

--- a/documentation/test_doxygen/page_empty_page/input.h
+++ b/documentation/test_doxygen/page_empty_page/input.h
@@ -1,0 +1,13 @@
+/// @defgroup bla A module
+/// @brief Short module description
+/// @{
+
+/// @brief A namespace
+namespace foo {
+
+/// @brief A class
+class bar {};
+
+}
+
+/// @}

--- a/documentation/test_doxygen/page_empty_page/input.md
+++ b/documentation/test_doxygen/page_empty_page/input.md
@@ -1,0 +1,12 @@
+@ingroup bla
+
+[comment]: # (The `ingroup` statement above avoids the generation of an empty page for this file.)
+[comment]: # (The actual group we add the file to is irrelevant, nothing is actually added.)
+[comment]: # (Doxygen will actually create xml/group__bla_md_input.xml, but we want to avoid)
+[comment]: # (creating html/group__bla_md_input.html, and listing `input` on the list of pages.)
+
+@class foo::bar
+
+This is the detailed description for class `foo::bar``.
+We put it in a separate file to not clutter the header file too much.
+Because this is a really loooong description!

--- a/documentation/test_doxygen/page_empty_page/pages.html
+++ b/documentation/test_doxygen/page_empty_page/pages.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>My Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>Pages</h2>
+        <ul class="m-doc">
+        </ul>
+        <script>
+        function toggle(e) {
+            e.parentElement.className = e.parentElement.className == 'm-doc-collapsible' ?
+                'm-doc-expansible' : 'm-doc-collapsible';
+            return false;
+        }
+        /* Collapse all nodes marked as such. Doing it via JS instead of
+           directly in markup so disabling it doesn't harm usability. The list
+           is somehow regenerated on every iteration and shrinks as I change
+           the classes. It's not documented anywhere and I'm not sure if this
+           is the same across browsers, so I am going backwards in that list to
+           be sure. */
+        var collapsed = document.getElementsByClassName("collapsed");
+        for(var i = collapsed.length - 1; i >= 0; --i)
+            collapsed[i].className = 'm-doc-expansible';
+        </script>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_doxygen/test_page.py
+++ b/documentation/test_doxygen/test_page.py
@@ -100,3 +100,13 @@ class SubpageOfIndex(IntegrationTestCase):
         self.run_doxygen(wildcard='*.xml')
         self.assertEqual(*self.actual_expected_contents('page.html'))
         self.assertEqual(*self.actual_expected_contents('pages.html'))
+
+class EmptyPage(IntegrationTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(__file__, 'empty_page', *args, **kwargs)
+
+    def test(self):
+        self.run_doxygen(wildcard='*.xml')
+        self.assertEqual(*self.actual_expected_contents('pages.html'))
+        # TODO: test to ensure html/group__bla_md_input.html does not exist
+


### PR DESCRIPTION
This is a simple fix that avoids empty pages in the case a markdown file is used to document members. 

The first commit adds a text case, which illustrates the issue. The second commit fixes `doxygen.py` to avoid these empty pages.

In the test case, plain Doxygen does not create the file `html/group__bla_md_input.html`, but `doxygen.py` does, and adds "input" on the list of pages.