### PR TITLE
Fixed link to defines section

### DIFF
--- a/documentation/templates/doxygen/base-reference.html
+++ b/documentation/templates/doxygen/base-reference.html
@@ -178,8 +178,8 @@
         </section>
         {% endif %}
         {% if compound.defines %}
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             {% for define in compound.defines %}
 {{ entry_define(define) }}

--- a/documentation/test_doxygen/compound_deprecated/DeprecatedFile_8h.html
+++ b/documentation/test_doxygen/compound_deprecated/DeprecatedFile_8h.html
@@ -65,8 +65,8 @@
             <dd>A struct.</dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="#a7f8376730349fef9ff7d103b0245a13e" class="m-doc">DEPRECATED_MACRO</a>(</span><span class="m-doc-wrap">a,

--- a/documentation/test_doxygen/compound_detailed/File_8h.html
+++ b/documentation/test_doxygen/compound_detailed/File_8h.html
@@ -73,8 +73,8 @@
             <dd>Class with wrong template parameter description.</dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="#a144a2a84c08d05de76f6a4a245584810" class="m-doc">A_DEFINE</a></span>

--- a/documentation/test_doxygen/compound_includes/group__group.html
+++ b/documentation/test_doxygen/compound_includes/group__group.html
@@ -73,8 +73,8 @@
             <dd>A variable.</dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="#ga144a2a84c08d05de76f6a4a245584810" class="m-doc">A_DEFINE</a></span>

--- a/documentation/test_doxygen/compound_includes_disabled/group__group.html
+++ b/documentation/test_doxygen/compound_includes_disabled/group__group.html
@@ -73,8 +73,8 @@
             <dd>A variable.</dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="#ga144a2a84c08d05de76f6a4a245584810" class="m-doc-self" name="ga144a2a84c08d05de76f6a4a245584810">A_DEFINE</a></span>

--- a/documentation/test_doxygen/compound_listing/File_8h.html
+++ b/documentation/test_doxygen/compound_listing/File_8h.html
@@ -79,8 +79,8 @@
             <dd>An union.</dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="#a144a2a84c08d05de76f6a4a245584810" class="m-doc-self" name="a144a2a84c08d05de76f6a4a245584810">A_DEFINE</a></span>

--- a/documentation/test_doxygen/compound_modules_in_namespace/file3_8h.html
+++ b/documentation/test_doxygen/compound_modules_in_namespace/file3_8h.html
@@ -56,8 +56,8 @@
             <dd>And another function here.</dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="group__group2.html#ga144a2a84c08d05de76f6a4a245584810" class="m-doc">A_DEFINE</a></span>

--- a/documentation/test_doxygen/compound_modules_in_namespace/group__group2.html
+++ b/documentation/test_doxygen/compound_modules_in_namespace/group__group2.html
@@ -61,8 +61,8 @@
             <dd>Lets define yet another function.</dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="#ga144a2a84c08d05de76f6a4a245584810" class="m-doc">A_DEFINE</a></span>

--- a/documentation/test_doxygen/compound_namespace_members_in_file_scope/File_8h.html
+++ b/documentation/test_doxygen/compound_namespace_members_in_file_scope/File_8h.html
@@ -130,8 +130,8 @@
             <dd>Variable with just a brief.</dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="#a1e6e7cc6cc96adc8342c838f55790259" class="m-doc">A_MACRO</a></span>

--- a/documentation/test_doxygen/compound_namespace_members_in_file_scope_define_base_url/File_8h.html
+++ b/documentation/test_doxygen/compound_namespace_members_in_file_scope_define_base_url/File_8h.html
@@ -43,8 +43,8 @@
             <dd>A namespace.</dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="#a144a2a84c08d05de76f6a4a245584810" class="m-doc-self" name="a144a2a84c08d05de76f6a4a245584810">A_DEFINE</a></span>

--- a/documentation/test_doxygen/contents_unexpected_sections/File_8h.html
+++ b/documentation/test_doxygen/contents_unexpected_sections/File_8h.html
@@ -66,8 +66,8 @@
             <dd>A variable.</dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="#afac708c45da370b4c1304f4b69f7fc75" class="m-doc-self" name="afac708c45da370b4c1304f4b69f7fc75">FOOBAR</a></span>

--- a/documentation/test_doxygen/undocumented/File_8h.html
+++ b/documentation/test_doxygen/undocumented/File_8h.html
@@ -191,8 +191,8 @@
             <dd><span></span></dd>
           </dl>
         </section>
-        <section id="define-members">
-          <h2><a href="#define-members">Defines</a></h2>
+        <section id="defines">
+          <h2><a href="#defines">Defines</a></h2>
           <dl class="m-doc">
             <dt>
               <span class="m-doc-wrap-bumper">#define <a href="#a144a2a84c08d05de76f6a4a245584810" class="m-doc-self" name="a144a2a84c08d05de76f6a4a245584810">A_DEFINE</a></span>


### PR DESCRIPTION
The menu at the top of a header file or group page had a broken link to the section containing the preprocessor macros ("Defines"). The link referenced a section called "defines", but the section itself was "define-members".

I've changed the tests to match the change in the template, but not run the test. I hope Travis is happy with my changes. ;)