### PR TITLE
Allow showing private members

### DIFF
--- a/documentation/doxygen.py
+++ b/documentation/doxygen.py
@@ -2500,6 +2500,7 @@ def parse_xml(state: State, xml: str):
     compound.protected_vars = []
     compound.private_funcs = []
     compound.private_slots = []
+    compound.private_vars = []
     compound.related = []
     compound.friend_funcs = []
     compound.groups = []
@@ -2882,7 +2883,7 @@ def parse_xml(state: State, xml: str):
                 # Gather only private functions that are virtual and
                 # documented
                 for memberdef in compounddef_child:
-                    if memberdef.attrib['virt'] == 'non-virtual' or (not memberdef.find('briefdescription').text and not memberdef.find('detaileddescription').text):
+                    if (memberdef.attrib['virt'] == 'non-virtual' and state.doxyfile['EXTRACT_PRIVATE']) or (not memberdef.find('briefdescription').text and not memberdef.find('detaileddescription').text):
                         assert True # coverage.py can't handle continue
                         continue # pragma: no cover
 
@@ -2893,6 +2894,13 @@ def parse_xml(state: State, xml: str):
                         else:
                             compound.private_funcs += [func]
                         if func.has_details: compound.has_func_details = True
+
+            elif compounddef_child.attrib['kind'] == 'private-attrib' and state.doxyfile['EXTRACT_PRIVATE']:
+                for memberdef in compounddef_child:
+                    var = parse_var(state, memberdef)
+                    if var:
+                        compound.private_vars += [var]
+                        if var.has_details: compound.has_var_details = True
 
             elif compounddef_child.attrib['kind'] == 'related':
                 for memberdef in compounddef_child:
@@ -3316,6 +3324,7 @@ def parse_doxyfile(state: State, doxyfile, config = None):
         'PROJECT_NAME': ['My Project'],
         'PROJECT_LOGO': [''],
         'OUTPUT_DIRECTORY': [''],
+        'EXTRACT_PRIVATE': ['NO'],
         'XML_OUTPUT': ['xml'],
         'HTML_OUTPUT': ['html'],
         'HTML_EXTRA_STYLESHEET': [
@@ -3470,6 +3479,7 @@ copy a link to the result using <span class="m-label m-dim">⌘</span>
               'QT_AUTOBRIEF',
               'INTERNAL_DOCS',
               'SHOW_INCLUDE_FILES',
+              'EXTRACT_PRIVATE',
               'M_EXPAND_INNER_TYPES',
               'M_SEARCH_DISABLED',
               'M_SEARCH_DOWNLOAD_BINARY',

--- a/documentation/templates/doxygen/base-class-reference.html
+++ b/documentation/templates/doxygen/base-class-reference.html
@@ -49,7 +49,7 @@
           </tbody>
         </table>
         {% endif %}
-        {% if compound.sections or compound.public_types or compound.public_static_funcs or compound.typeless_funcs or compound.public_funcs or compound.signals or compound.public_slots or compound.public_static_vars or compound.public_vars or compound.protected_types or compound.protected_static_funcs or compound.protected_funcs or compound.protected_signals or compound.protected_static_vars or compound.protected_vars or compound.private_funcs or compound.private_slots or compound.groups or compound.friend_funcs or compound.related %}
+        {% if compound.sections or compound.public_types or compound.public_static_funcs or compound.typeless_funcs or compound.public_funcs or compound.signals or compound.public_slots or compound.public_static_vars or compound.public_vars or compound.protected_types or compound.protected_static_funcs or compound.protected_funcs or compound.protected_signals or compound.protected_static_vars or compound.protected_vars or compound.private_funcs or compound.private_slots or compound.private_vars or compound.groups or compound.friend_funcs or compound.related %}
         <div class="m-block m-default">
           <h3>Contents</h3>
           <ul>
@@ -121,6 +121,9 @@
                 {% endif %}
                 {% if compound.private_slots %}
                 <li><a href="#pri-slots">Private slots</a></li>
+                {% endif %}
+                {% if compound.private_vars %}
+                <li><a href="#pri-attribs">Private variables</a></li>
                 {% endif %}
                 {% for group in compound.groups %}
                 <li><a href="#{{ group.id }}">{{ group.name }}</a></li>
@@ -317,6 +320,16 @@
           <dl class="m-doc">
             {% for func in compound.private_funcs %}
 {{ entry_func(func) }}
+            {% endfor %}
+          </dl>
+        </section>
+        {% endif %}
+        {% if compound.private_vars %}
+        <section id="pri-attribs">
+          <h2><a href="#pri-attribs">Private variables</a></h2>
+          <dl class="m-doc">
+            {% for var in compound.private_vars %}
+{{ entry_var(var) }}
             {% endfor %}
           </dl>
         </section>
@@ -531,6 +544,11 @@
 {{ details_var(var, compound.prefix_wbr) }}
           {% endif %}
           {% endfor %}
+          {% for var in compound.private_vars %}
+          {% if var.has_details %}
+{{ details_var(var, compound.prefix_wbr) }}
+          {% endif %}
+          {% endfor %}
           {% for group in compound.groups %}
           {% for kind, member in group.members %}
           {% if kind == 'var' and member.has_details %}
@@ -556,4 +574,3 @@
         </section>
         {% endif %}
 {% endblock %}
-


### PR DESCRIPTION
Add support for the EXTRACT_PRIVATE doxygen configuration option.
Private members were previously ignored, as stated [in the main page](https://mcss.mosra.cz/documentation/doxygen/#important-differences-to-stock-html-output)

Why things aren't perfect:
	1) there is no `virtual` label like there is for `private` and `override`
	That would be a plus, but I have no idea where to check for that.
	2) My fix seems too simple to take care of all cases. Please review thoroughly
	3) I did not add tests.
