### PR TITLE
do not show the doxygen thingy at bottom  when not needed 

### DIFF
--- a/documentation/templates/doxygen/base.html
+++ b/documentation/templates/doxygen/base.html
@@ -152,7 +152,7 @@
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
         {% if M_PAGE_FINE_PRINT == '[default]' %}
-        <p>{{ PROJECT_NAME }}{% if PROJECT_BRIEF %} {{ PROJECT_BRIEF }}{% endif %}. Created with <a href="https://doxygen.org/">Doxygen</a> {{ DOXYGEN_VERSION }} and <a href="https://mcss.mosra.cz/">m.css</a>.</p>
+        <p>{{ PROJECT_NAME }}{% if PROJECT_BRIEF %} {{ PROJECT_BRIEF }}{% endif %}. Created with {% if not DOXYGEN_VERSION == '0'%}<a href="https://doxygen.org/">Doxygen</a> {{ DOXYGEN_VERSION }} and {% endif %}<a href="https://mcss.mosra.cz/">m.css</a>.</p>
         {% else %}
         {{ M_PAGE_FINE_PRINT|replace('{doxygen_version}', DOXYGEN_VERSION) }}
         {% endif %}


### PR DESCRIPTION
in doxygen.py, line 3606, the doxygen version is set to 0 when outputting the main page, because it is done without the help of doxygen. This results in a page with "Created with Doxygen 0 and m.css."

With this PR, the output is "Created with m.

I can make tests if needed, but do have no idea how to test this particular feature (apart from testing).

Here's an example page that uses it: https://marr11317.github.io/Musescore-docs/mcss/index.html