### PR TITLE
wrap page/article content in blocks for easier extension of templates

### DIFF
--- a/pelican-theme/templates/article.html
+++ b/pelican-theme/templates/article.html
@@ -93,7 +93,9 @@
           {{ M_ARCHIVED_ARTICLE_BADGE|render_rst|replace('{year}', article.date.year)|indent(8) }}
           {% endif %}
 <!-- content -->
+{% block article_content %}
 {{ article.content|trim }}
+{% endblock %}
 <!-- /content -->
           {% if article.category.badge or (article.author and article.author.badge) %}
           {{ badges()|rtrim|indent(10) }}
@@ -121,7 +123,9 @@
       {% endif %}
       {% if article.content %}
 <!-- content -->
+{% block article_content %}
 {{ article.content|trim }}
+{% endblock %}
 <!-- /content -->
       {% endif %}
       {% if article.category.badge or (article.author and article.author.badge) %}

--- a/pelican-theme/templates/page.html
+++ b/pelican-theme/templates/page.html
@@ -117,7 +117,9 @@
         {% endif %}
         {% if page.content %}
 <!-- content -->
+{% block page_content %}
 {{ page.content|trim }}
+{% endblock %}
 <!-- /content -->
         {% endif %}
       </div>

--- a/pelican-theme/templates/passthrough.html
+++ b/pelican-theme/templates/passthrough.html
@@ -21,6 +21,8 @@
   {% endif %}
 </head>
 <body>
+{% block page_content %}
 {{- page.content -}}
+{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Dear @mosra,

thanks for this great theme.

This PR wraps, where useful, all `[page|article].content`s in Jinja blocks for easier (as in "less verbose") extension/customization/overriding of templates.

An example use case is to build a custom index page using the `page.html` template. Say we want to add some Jinja-powered content before the rendered `page.content` itself. In the current revision, we'd have to copy the whole `main` block. Over time, we'd have to maintain this copy in order to stay in sync with the theme's development. This use case could be achieved way less verbose if we could extend `page.html` and only override the part where the rendered content is inserted.