### PR TITLE
Improve pybind11 default argument & type parsing

### DIFF
--- a/documentation/python.py
+++ b/documentation/python.py
@@ -840,12 +840,15 @@ def parse_pybind_type(state: State, referrer_path: List[str], signature: str):
             type_link += c
             continue
         match = _pybind_type_rx.match(signature[i:])
+        if match is None:
+            raise SyntaxError("Bad python type name: {} ".format(signature[i:]))
         input_type = match.group(0)
         i += len(input_type)
         input_type = map_name_prefix_or_add_typing_suffix(state, input_type)
         type += input_type
         type_link += make_name_link(state, referrer_path, input_type)
-    assert lvl == 0
+    if lvl != 0:
+        raise SyntaxError("Unbalanced [] in python type {}".format(signature))
     signature = signature[i:]
     return signature, type, type_link
 

--- a/documentation/python.py
+++ b/documentation/python.py
@@ -794,7 +794,7 @@ def _pybind11_default_argument_length(string):
         elif c == '[':
             stack.append(']')
         elif c == ')' or c == ']':
-            if c != stack.pop():
+            if len(stack) == 0 or c != stack.pop():
                 raise SyntaxError("Unmatched {} at pos {} in `{}`".format(c, i, string))
     raise SyntaxError("Unexpected end of `{}`".format(string))
 

--- a/documentation/python.py
+++ b/documentation/python.py
@@ -781,7 +781,23 @@ def make_name_link(state: State, referrer_path: List[str], name) -> str:
 _pybind_name_rx = re.compile('[a-zA-Z0-9_]*')
 _pybind_arg_name_rx = re.compile('[*a-zA-Z0-9_]+')
 _pybind_type_rx = re.compile('[a-zA-Z0-9_.]+')
-_pybind_default_value_rx = re.compile('[^,)]+')
+
+
+def _pybind11_default_argument_length(string):
+    """Returns length of balanced []()-expression at begin of input string until `,` or `)`"""
+    stack = []
+    for i, c in enumerate(string):
+        if len(stack) == 0 and (c == ',' or c == ')'):
+            return i
+        if c == '(':
+            stack.append(')')
+        elif c == '[':
+            stack.append(']')
+        elif c == ')' or c == ']':
+            if c != stack.pop():
+                raise SyntaxError("Unmatched {} at pos {} in `{}`".format(c, i, string))
+    raise SyntaxError("Unexpected end of `{}`".format(string))
+
 
 def parse_pybind_type(state: State, referrer_path: List[str], signature: str) -> str:
     # If this doesn't match, it's because we're in Callable[[arg, ...], retval]
@@ -857,14 +873,14 @@ def parse_pybind_signature(state: State, referrer_path: List[str], signature: st
                 arg_type = None
                 arg_type_link = None
 
-            # Default (optional) -- for now take everything until the next comma
-            # TODO: ugh, do properly
+            # Default (optional)
             # The equals has spaces around since 2.3.0, preserve 2.2 compatibility.
             # https://github.com/pybind/pybind11/commit/0826b3c10607c8d96e1d89dc819c33af3799a7b8
             if signature.startswith(('=', ' = ')):
                 signature = signature[1 if signature[0] == '=' else 3:]
-                default = _pybind_default_value_rx.match(signature).group(0)
-                signature = signature[len(default):]
+                default_length = _pybind11_default_argument_length(signature)
+                default = signature[:default_length]
+                signature = signature[default_length:]
             else:
                 default = None
 

--- a/documentation/python.py
+++ b/documentation/python.py
@@ -800,7 +800,7 @@ def _pybind11_default_argument_length(string):
 
 
 def map_name_prefix_or_add_typing_suffix(state: State, input_type: str):
-    if input_type in ['Callable', 'Dict', 'Iterator', 'List', 'Optional', 'Set', 'Tuple', 'Union']:
+    if input_type in ['Callable', 'Dict', 'Iterator', 'Iterable', 'List', 'Optional', 'Set', 'Tuple', 'Union']:
         return 'typing.' + input_type
     else:
         return map_name_prefix(state, input_type)

--- a/documentation/test_python/test_pybind.py
+++ b/documentation/test_python/test_pybind.py
@@ -209,6 +209,12 @@ class Signature(unittest.TestCase):
         self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float = ))'), bad_signature)
         self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float = ])'), bad_signature)
 
+    def test_pybind11_bad_return_type(self):
+        bad_signature = ('foo', '', [('…', None, None, None)], None, None)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo() -> List[[]'), bad_signature)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo() -> List]'), bad_signature)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo() -> ::std::vector<int>'), bad_signature)
+
 
     def test_crazy_stuff(self):
         self.assertEqual(parse_pybind_signature(self.state, [],

--- a/documentation/test_python/test_pybind.py
+++ b/documentation/test_python/test_pybind.py
@@ -136,6 +136,35 @@ class Signature(unittest.TestCase):
                 ('b', 'str', 'str', '\'hello\''),
             ], None, None))
 
+        self.assertEqual(parse_pybind_signature(self.state, [],
+            'foo(a: float=libA.foo(libB.goo(123), libB.bar + 13) + 2, b=3)'),
+            ('foo', '', [
+                ('a', 'float', 'float', 'libA.foo(libB.goo(123), libB.bar + 13) + 2'),
+                ('b', None, None, '3'),
+            ], None, None))
+
+        self.assertEqual(parse_pybind_signature(self.state, [],
+            'foo(a: List=[1, 2, 3], b: Tuple=(1, 2, 3, "str"))'),
+            ('foo', '', [
+                ('a', 'typing.List', 'typing.List', '[1, 2, 3]'),
+                ('b', "typing.Tuple", "typing.Tuple", '(1, 2, 3, "str")'),
+            ], None, None))
+
+        self.assertEqual(parse_pybind_signature(self.state, [],
+            'foo(a: Tuple[int, ...]=(1,("hello", \'world\'),3,4))'),
+            ('foo', '', [
+                ('a', 'typing.Tuple[int, ...]',
+                      'typing.Tuple[int, ...]',
+                 '(1,("hello", \'world\'),3,4)')
+            ], None, None))
+
+        self.assertEqual(parse_pybind_signature(self.state, [],
+            'foo(a: str=[dict(key="A", value=\'B\')["key"][0], None][0])'),
+             ('foo', '', [
+                 ('a', 'str', 'str', '[dict(key="A", value=\'B\')["key"][0], None][0]')
+             ], None, None))
+
+
     def test_default_values_pybind23(self):
         self.assertEqual(parse_pybind_signature(self.state, [],
             'foo(a: float = 1.0, b: str = \'hello\')'),
@@ -143,6 +172,28 @@ class Signature(unittest.TestCase):
                 ('a', 'float', 'float', '1.0'),
                 ('b', 'str', 'str', '\'hello\''),
             ], None, None))
+
+        self.assertEqual(parse_pybind_signature(self.state, [],
+            'foo(a: float = libA.foo(libB.goo(123), libB.bar + 13) + 2, b=3)'),
+            ('foo', '', [
+                ('a', 'float', 'float', 'libA.foo(libB.goo(123), libB.bar + 13) + 2'),
+                ('b', None, None, '3'),
+            ], None, None))
+
+        self.assertEqual(parse_pybind_signature(self.state, [],
+            'foo(a: Tuple[int, ...] = (1,("hello", \'world\'),3,4))'),
+            ('foo', '', [
+                ('a', 'typing.Tuple[int, ...]',
+                      'typing.Tuple[int, ...]',
+                 '(1,("hello", \'world\'),3,4)')
+            ], None, None))
+
+        self.assertEqual(parse_pybind_signature(self.state, [],
+            'foo(a: str = [dict(key="A", value=\'B\')["key"][0], None][0])'),
+             ('foo', '', [
+                 ('a', 'str', 'str', '[dict(key="A", value=\'B\')["key"][0], None][0]')
+             ], None, None))
+
 
     def test_crazy_stuff(self):
         self.assertEqual(parse_pybind_signature(self.state, [],

--- a/documentation/test_python/test_pybind.py
+++ b/documentation/test_python/test_pybind.py
@@ -164,6 +164,13 @@ class Signature(unittest.TestCase):
                  ('a', 'str', 'str', '[dict(key="A", value=\'B\')["key"][0], None][0]')
              ], None, None))
 
+        bad_signature = ('foo', '', [('…', None, None, None)], None, None)
+
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float=[0][)'), bad_signature)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float=()'), bad_signature)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float=(()'), bad_signature)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float=))'), bad_signature)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float=])'), bad_signature)
 
     def test_default_values_pybind23(self):
         self.assertEqual(parse_pybind_signature(self.state, [],
@@ -193,6 +200,14 @@ class Signature(unittest.TestCase):
              ('foo', '', [
                  ('a', 'str', 'str', '[dict(key="A", value=\'B\')["key"][0], None][0]')
              ], None, None))
+
+        bad_signature = ('foo', '', [('…', None, None, None)], None, None)
+        
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float = [0][)'), bad_signature)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float = ()'), bad_signature)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float = (()'), bad_signature)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float = ))'), bad_signature)
+        self.assertEqual(parse_pybind_signature(self.state, [], 'foo(a: float = ])'), bad_signature)
 
 
     def test_crazy_stuff(self):


### PR DESCRIPTION
Parse default argument as `[]/()`-balanced expression without outter comma.
Types parsing changed to accept `<identifier>[<balanced-squared-bracket-expression>]?`.

Tested on [gemmi project](https://github.com/project-gemmi/gemmi).

nofix gotcha: strictly speaking default argument might be represented as arbitrary string by means of `py::arg_v`.