### PR TITLE
Support nested pages (python.py)

### DIFF
--- a/documentation/python.py
+++ b/documentation/python.py
@@ -2360,9 +2360,13 @@ def render_page(state: State, path, input_filename, env):
                     value = body_elem.astext()
                 metadata[name.lower()] = value
 
-    # Breadcrumb, we don't do page hierarchy yet
-    # assert len(path) == 1
-    page.breadcrumb = [(pub.writer.parts.get('title'), url)]
+    site_root = ['..'] * url.count('/')  # relative to generated page
+    breadcrumb = []
+    for i in range(len(path) - (1 if path[-1] != "index" else 2)):
+        parent_path = path[:i + 1] + ['index']
+        parent = state.name_map['.'.join(parent_path)]
+        breadcrumb += [(parent.name, '/'.join(site_root + [parent.url]))]
+    page.breadcrumb = breadcrumb + [(pub.writer.parts.get('title'), url)]
 
     # Set page content and add extra metadata from there
     page.content = pub.writer.parts.get('body').rstrip()

--- a/documentation/python.py
+++ b/documentation/python.py
@@ -2153,13 +2153,18 @@ def get_reference_patcher(site_root, config):
             Transform.__init__(self, document, startnode=startnode)
 
         def apply(self):
-            for ref in self.document.traverse(docutils.nodes.reference):
-                if 'refuri' in ref.attributes:
-                    old = ref.attributes['refuri']
-                    new = format_url(old, config, site_root)
-                    if old != new:
-                        ref.attributes['refuri'] = new
-                        logging.debug("reference patched {} -> {} ".format(old, new))
+            for attr, node_type in [
+                ('uri', docutils.nodes.image),
+                ('refuri', docutils.nodes.reference)
+            ]:
+                for ref in self.document.traverse(node_type):
+                    if attr in ref.attributes:
+                        old = ref.attributes[attr]
+                        new = format_url(old, config, site_root)
+                        if old != new:
+                            ref.attributes[attr] = new
+                            logging.debug("reference patched {} -> {} ".format(old, new))
+
     return PatchReferences
 
 

--- a/documentation/python.py
+++ b/documentation/python.py
@@ -1902,6 +1902,11 @@ def render(*, state, template: str, url: str, filename: str, env: jinja2.Environ
         entry = state.name_map['.'.join(path)]
         return '/'.join(site_root + [entry.url])  # TODO: url shortening can be applied
 
+    # 'format_url' and 'path_to_url' does not take arguments
+    # therefore reasonably treated as stateless by Jinja and cached
+    # A better alternative to cache.clear() would be to pass site_root argument to those filters
+    env.cache.clear()
+
     env.filters['format_url'] = lambda path: format_url(path, config, site_root)
     env.filters['path_to_url'] = path_to_url
 

--- a/documentation/python.py
+++ b/documentation/python.py
@@ -2566,7 +2566,7 @@ def run(basedir, config, *, templates=default_templates, search_add_lookahead_ba
 
         entry = Empty()
         entry.type = EntryType.PAGE
-        entry.path = [parent.name for parent in page_path.parents if parent.name not in ['', '.']] + [page_name]
+        entry.path = [parent.name for parent in page_path.parents if parent.name not in ['', '.']][::-1] + [page_name]
         entry.url = config['URL_FORMATTER'](EntryType.PAGE, entry.path)[1]
         entry.filename = os.path.join(config['INPUT'], page)
         # using '.' for pages avoids diversity of separator in `path -> name_map key` conversions (there are many)

--- a/documentation/templates/python/page.html
+++ b/documentation/templates/python/page.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 
-{% block title %}{% set j = joiner('.') %}{% for name, _ in page.breadcrumb %}{{ j() }}{{ name }}{% endfor %} | {{ super() }}{% endblock %}
+{% block title %}{% set j = joiner(' &raquo; ') %}{% for name, _ in page.breadcrumb %}{{ j() }}{{ name }}{% endfor %} | {{ super() }}{% endblock %}
 
 {% block main %}
         <h1>
-          {%+ for name, target in page.breadcrumb[:-1] %}<span class="m-breadcrumb"><a href="{{ target }}">{{ name }}</a>.<wbr/></span>{% endfor %}{{ page.breadcrumb[-1][0] }}
+          {%+ for name, target in page.breadcrumb[:-1] %}<span class="m-breadcrumb"><a href="{{ target }}">{{ name }}</a> &raquo; <wbr/></span>{% endfor %}{{ page.breadcrumb[-1][0] }}
         </h1>
         {% if page.summary %}
         <p>{{ page.summary }}</p>

--- a/documentation/test_python/page_nested/classes.html
+++ b/documentation/test_python/page_nested/classes.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>Classes</h2>
+        <ul class="m-doc">
+        </ul>
+        <script>
+        function toggle(e) {
+            e.parentElement.className = e.parentElement.className == 'm-doc-collapsible' ?
+                'm-doc-expansible' : 'm-doc-collapsible';
+            return false;
+        }
+        /* Collapse all nodes marked as such. Doing it via JS instead of
+           directly in markup so disabling it doesn't harm usability. The list
+           is somehow regenerated on every iteration and shrinks as I change
+           the classes. It's not documented anywhere and I'm not sure if this
+           is the same across browsers, so I am going backwards in that list to
+           be sure. */
+        var collapsed = document.getElementsByClassName("collapsed");
+        for(var i = collapsed.length - 1; i >= 0; --i)
+            collapsed[i].className = 'm-doc-expansible';
+        </script>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/page_nested/examples/advanced/barz.html
+++ b/documentation/test_python/page_nested/examples/advanced/barz.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Examples &raquo; Advanced &raquo; Barz | My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="../../m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="../../index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>
+          <span class="m-breadcrumb"><a href="../../examples/index.html">Examples</a> &raquo; <wbr/></span><span class="m-breadcrumb"><a href="../../examples/advanced/index.html">Advanced</a> &raquo; <wbr/></span>Barz
+        </h1>
+<p>Barz example</p>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/page_nested/examples/advanced/barz.rst
+++ b/documentation/test_python/page_nested/examples/advanced/barz.rst
@@ -1,0 +1,4 @@
+Barz
+####
+
+Barz example

--- a/documentation/test_python/page_nested/examples/advanced/fooz.html
+++ b/documentation/test_python/page_nested/examples/advanced/fooz.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Examples &raquo; Advanced &raquo; Fooz | My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="../../m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="../../index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>
+          <span class="m-breadcrumb"><a href="../../examples/index.html">Examples</a> &raquo; <wbr/></span><span class="m-breadcrumb"><a href="../../examples/advanced/index.html">Advanced</a> &raquo; <wbr/></span>Fooz
+        </h1>
+<p>Fooz example</p>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/page_nested/examples/advanced/fooz.rst
+++ b/documentation/test_python/page_nested/examples/advanced/fooz.rst
@@ -1,0 +1,4 @@
+Fooz
+####
+
+Fooz example

--- a/documentation/test_python/page_nested/examples/advanced/index.html
+++ b/documentation/test_python/page_nested/examples/advanced/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Examples &raquo; Advanced | My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="../../m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="../../index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>
+          <span class="m-breadcrumb"><a href="../../examples/index.html">Examples</a> &raquo; <wbr/></span>Advanced
+        </h1>
+<p>List of advanced examples</p>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/page_nested/examples/advanced/index.rst
+++ b/documentation/test_python/page_nested/examples/advanced/index.rst
@@ -1,0 +1,5 @@
+Advanced
+########
+
+List of advanced examples
+

--- a/documentation/test_python/page_nested/examples/bar.html
+++ b/documentation/test_python/page_nested/examples/bar.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Examples &raquo; Bar | My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="../m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="../index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>
+          <span class="m-breadcrumb"><a href="../examples/index.html">Examples</a> &raquo; <wbr/></span>Bar
+        </h1>
+<p>Bar example</p>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/page_nested/examples/bar.rst
+++ b/documentation/test_python/page_nested/examples/bar.rst
@@ -1,0 +1,4 @@
+Bar
+###
+
+Bar example

--- a/documentation/test_python/page_nested/examples/foo.html
+++ b/documentation/test_python/page_nested/examples/foo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Examples &raquo; Foo | My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="../m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="../index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>
+          <span class="m-breadcrumb"><a href="../examples/index.html">Examples</a> &raquo; <wbr/></span>Foo
+        </h1>
+<p>Foo example</p>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/page_nested/examples/foo.rst
+++ b/documentation/test_python/page_nested/examples/foo.rst
@@ -1,0 +1,4 @@
+Foo
+###
+
+Foo example

--- a/documentation/test_python/page_nested/examples/index.html
+++ b/documentation/test_python/page_nested/examples/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Examples | My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="../m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="../index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>
+          Examples
+        </h1>
+<p>List of basic examples</p>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/page_nested/examples/index.rst
+++ b/documentation/test_python/page_nested/examples/index.rst
@@ -1,0 +1,4 @@
+Examples
+########
+
+List of basic examples

--- a/documentation/test_python/page_nested/index.html
+++ b/documentation/test_python/page_nested/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Main Page | My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>
+          Main Page
+        </h1>
+<p>This page is not shown in the page tree.</p>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/page_nested/index.rst
+++ b/documentation/test_python/page_nested/index.rst
@@ -1,0 +1,1 @@
+../page/index.rst

--- a/documentation/test_python/page_nested/modules.html
+++ b/documentation/test_python/page_nested/modules.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>Modules</h2>
+        <ul class="m-doc">
+        </ul>
+        <script>
+        function toggle(e) {
+            e.parentElement.className = e.parentElement.className == 'm-doc-collapsible' ?
+                'm-doc-expansible' : 'm-doc-collapsible';
+            return false;
+        }
+        /* Collapse all nodes marked as such. Doing it via JS instead of
+           directly in markup so disabling it doesn't harm usability. The list
+           is somehow regenerated on every iteration and shrinks as I change
+           the classes. It's not documented anywhere and I'm not sure if this
+           is the same across browsers, so I am going backwards in that list to
+           be sure. */
+        var collapsed = document.getElementsByClassName("collapsed");
+        for(var i = collapsed.length - 1; i >= 0; --i)
+            collapsed[i].className = 'm-doc-expansible';
+        </script>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/page_nested/pages.html
+++ b/documentation/test_python/page_nested/pages.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>Pages</h2>
+        <ul class="m-doc">
+          <li><a href="examples/index.html" class="m-doc">Examples</a> <span class="m-doc"></span></li>
+          <li><a href="examples/foo.html" class="m-doc">Foo</a> <span class="m-doc"></span></li>
+          <li><a href="examples/bar.html" class="m-doc">Bar</a> <span class="m-doc"></span></li>
+          <li><a href="examples/advanced/index.html" class="m-doc">Advanced</a> <span class="m-doc"></span></li>
+          <li><a href="examples/advanced/fooz.html" class="m-doc">Fooz</a> <span class="m-doc"></span></li>
+          <li><a href="examples/advanced/barz.html" class="m-doc">Barz</a> <span class="m-doc"></span></li>
+        </ul>
+        <script>
+        function toggle(e) {
+            e.parentElement.className = e.parentElement.className == 'm-doc-collapsible' ?
+                'm-doc-expansible' : 'm-doc-collapsible';
+            return false;
+        }
+        /* Collapse all nodes marked as such. Doing it via JS instead of
+           directly in markup so disabling it doesn't harm usability. The list
+           is somehow regenerated on every iteration and shrinks as I change
+           the classes. It's not documented anywhere and I'm not sure if this
+           is the same across browsers, so I am going backwards in that list to
+           be sure. */
+        var collapsed = document.getElementsByClassName("collapsed");
+        for(var i = collapsed.length - 1; i >= 0; --i)
+            collapsed[i].className = 'm-doc-expansible';
+        </script>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/test_page.py
+++ b/documentation/test_python/test_page.py
@@ -44,6 +44,22 @@ class Page(BaseTestCase):
         self.assertEqual(*self.actual_expected_contents('error.html'))
         self.assertEqual(*self.actual_expected_contents('pages.html'))
 
+
+class Nested(BaseTestCase):
+    def test(self):
+        self.run_python({
+            'INPUT_PAGES': [
+                'index.rst',
+                'examples/index.rst',
+                'examples/foo.rst',
+                'examples/bar.rst',
+                'examples/advanced/index.rst',
+                'examples/advanced/fooz.rst',
+                'examples/advanced/barz.rst',
+            ]
+        })
+        self.assertEqual(*self.actual_expected_contents('index.html'))
+
 class InputSubdir(BaseTestCase):
     def test(self):
         self.run_python({


### PR DESCRIPTION

This PR adds basic support for nested pages for `python.py`. 

Changes:
 - alters `default_url_formatter` to generate `.html` tree same as input `.rst`
 - augments references and image sources in nested pages with appropriate number of `'../'` to point to right things (both `.rst`-generated code and in templates)
 - generate breadcrumb

I use relative paths because it would make possible to place C++ and Python API on same domain.

TODO:
 - Show nested structure in `pages`
 - Copy images with relative paths to avoid clashes
 - Avoid clearing jinja cache
 - Other stuff I forget about or didn't know at first place