### PR TITLE
Fix typo in closing tag name

### DIFF
--- a/documentation/templates/doxygen/annotated.html
+++ b/documentation/templates/doxygen/annotated.html
@@ -2,7 +2,7 @@
 {% extends 'base-index.html' %}
 
 {% block main %}
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           {% for i in index.symbols recursive %}
           {% if i.children %}

--- a/documentation/templates/doxygen/files.html
+++ b/documentation/templates/doxygen/files.html
@@ -2,7 +2,7 @@
 {% extends 'base-index.html' %}
 
 {% block main %}
-        <h1>Files</h2>
+        <h1>Files</h1>
         <ul class="m-doc">
           {% for i in index.files recursive %}
           {% if i.children %}

--- a/documentation/templates/doxygen/modules.html
+++ b/documentation/templates/doxygen/modules.html
@@ -2,7 +2,7 @@
 {% extends 'base-index.html' %}
 
 {% block main %}
-        <h1>Modules</h2>
+        <h1>Modules</h1>
         <ul class="m-doc">
           {% for i in index.modules recursive %}
           {% if i.has_nestable_children %}

--- a/documentation/templates/doxygen/namespaces.html
+++ b/documentation/templates/doxygen/namespaces.html
@@ -2,7 +2,7 @@
 {% extends 'base-index.html' %}
 
 {% block main %}
-        <h1>Namespaces</h2>
+        <h1>Namespaces</h1>
         <ul class="m-doc">
           {% for i in index.symbols|selectattr('kind', 'equalto', 'namespace') recursive %}
           {% if i.has_nestable_children %}

--- a/documentation/templates/doxygen/pages.html
+++ b/documentation/templates/doxygen/pages.html
@@ -2,7 +2,7 @@
 {% extends 'base-index.html' %}
 
 {% block main %}
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           {% for i in index.pages recursive %}
           {% if i.children %}

--- a/documentation/templates/python/classes.html
+++ b/documentation/templates/python/classes.html
@@ -2,7 +2,7 @@
 {% extends 'base-index.html' %}
 
 {% block main %}
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           {% for i in index.classes recursive %}
           {% if i.children %}

--- a/documentation/templates/python/modules.html
+++ b/documentation/templates/python/modules.html
@@ -2,7 +2,7 @@
 {% extends 'base-index.html' %}
 
 {% block main %}
-        <h1>Modules</h2>
+        <h1>Modules</h1>
         <ul class="m-doc">
           {% for i in index.classes|selectattr('kind', 'equalto', 'module') recursive %}
           {% if i.has_nestable_children %}

--- a/documentation/templates/python/pages.html
+++ b/documentation/templates/python/pages.html
@@ -2,7 +2,7 @@
 {% extends 'base-index.html' %}
 
 {% block main %}
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           {% for i in index.pages recursive %}
           {% if i.children %}

--- a/documentation/test_doxygen/compound_deprecated/annotated.html
+++ b/documentation/test_doxygen/compound_deprecated/annotated.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">namespace</a> <a href="namespaceDeprecatedNamespace.html" class="m-doc">DeprecatedNamespace</a> <span class="m-label m-danger">deprecated</span> <span class="m-doc">A namespace.</span>

--- a/documentation/test_doxygen/compound_deprecated/files.html
+++ b/documentation/test_doxygen/compound_deprecated/files.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Files</h2>
+        <h1>Files</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">dir</a> <a href="dir_da5033def2d0db76e9883b31b76b3d0c.html" class="m-doc">Dir</a> <span class="m-doc">A directory.</span>

--- a/documentation/test_doxygen/compound_deprecated/modules.html
+++ b/documentation/test_doxygen/compound_deprecated/modules.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Modules</h2>
+        <h1>Modules</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">module</a> <a href="group__group.html" class="m-doc">A group</a> <span class="m-doc"></span>

--- a/documentation/test_doxygen/compound_deprecated/namespaces.html
+++ b/documentation/test_doxygen/compound_deprecated/namespaces.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Namespaces</h2>
+        <h1>Namespaces</h1>
         <ul class="m-doc">
           <li>namespace <a href="namespaceDeprecatedNamespace.html" class="m-doc">DeprecatedNamespace</a> <span class="m-label m-danger">deprecated</span> <span class="m-doc">A namespace.</span></li>
         </ul>

--- a/documentation/test_doxygen/compound_deprecated/pages.html
+++ b/documentation/test_doxygen/compound_deprecated/pages.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)"></a><a href="deprecated-page.html" class="m-doc">Deprecated page</a> <span class="m-label m-danger">deprecated</span> <span class="m-doc"></span>

--- a/documentation/test_doxygen/compound_filename_case/pages.html
+++ b/documentation/test_doxygen/compound_filename_case/pages.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)"></a><a href="index.html" class="m-doc">My Project</a> <span class="m-doc"></span>

--- a/documentation/test_doxygen/compound_inline_namespace/annotated.html
+++ b/documentation/test_doxygen/compound_inline_namespace/annotated.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">namespace</a> <a href="namespaceFoo.html" class="m-doc">Foo</a> <span class="m-doc">A namespace.</span>

--- a/documentation/test_doxygen/compound_inline_namespace/namespaces.html
+++ b/documentation/test_doxygen/compound_inline_namespace/namespaces.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Namespaces</h2>
+        <h1>Namespaces</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">namespace</a> <a href="namespaceFoo.html" class="m-doc">Foo</a> <span class="m-doc">A namespace.</span>

--- a/documentation/test_doxygen/compound_listing/annotated.html
+++ b/documentation/test_doxygen/compound_listing/annotated.html
@@ -35,7 +35,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           <li>namespace <a href="namespaceAnother.html" class="m-doc">Another</a> <span class="m-doc">Another namespace.</span></li>
           <li class="m-doc-collapsible">

--- a/documentation/test_doxygen/compound_listing/files.html
+++ b/documentation/test_doxygen/compound_listing/files.html
@@ -35,7 +35,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Files</h2>
+        <h1>Files</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">dir</a> <a href="dir_56e20ab71e0974449b1654dd79ea6687.html" class="m-doc">Another</a> <span class="m-doc">Another directory.</span>

--- a/documentation/test_doxygen/compound_listing/namespaces.html
+++ b/documentation/test_doxygen/compound_listing/namespaces.html
@@ -35,7 +35,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Namespaces</h2>
+        <h1>Namespaces</h1>
         <ul class="m-doc">
           <li>namespace <a href="namespaceAnother.html" class="m-doc">Another</a> <span class="m-doc">Another namespace.</span></li>
           <li class="m-doc-collapsible">

--- a/documentation/test_doxygen/compound_listing/pages.html
+++ b/documentation/test_doxygen/compound_listing/pages.html
@@ -35,7 +35,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           <li><a href="page-no-toc.html" class="m-doc">Page without TOC</a> <span class="m-doc"></span></li>
         </ul>

--- a/documentation/test_doxygen/compound_modules/modules.html
+++ b/documentation/test_doxygen/compound_modules/modules.html
@@ -30,7 +30,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Modules</h2>
+        <h1>Modules</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">module</a> <a href="group__group.html" class="m-doc">A group</a> <span class="m-doc">Brief description. If this is not present, the detailed description gets interpreted as brief in 1.8.18. FFS.</span>

--- a/documentation/test_doxygen/compound_since/annotated.html
+++ b/documentation/test_doxygen/compound_since/annotated.html
@@ -36,7 +36,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">namespace</a> <a href="namespaceDeprecatedFoo.html" class="m-doc">DeprecatedFoo</a> <span class="m-label m-danger">deprecated since 2010.02</span> <span class="m-doc">A namespace.</span>

--- a/documentation/test_doxygen/compound_since/files.html
+++ b/documentation/test_doxygen/compound_since/files.html
@@ -36,7 +36,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Files</h2>
+        <h1>Files</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">dir</a> <a href="dir_73d1500434dee6f1c83b12ee799c54af.html" class="m-doc">DeprecatedDirectory</a> <span class="m-label m-danger">deprecated since 2010.02</span> <span class="m-doc">A dir with pretty old things.</span>

--- a/documentation/test_doxygen/compound_since/modules.html
+++ b/documentation/test_doxygen/compound_since/modules.html
@@ -36,7 +36,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Modules</h2>
+        <h1>Modules</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">module</a> <a href="group__group.html" class="m-doc">A group</a> <a href="changelog.html#changelog-2019-11" class="m-label m-success m-flat">since 2019.11</a> <span class="m-doc"></span>

--- a/documentation/test_doxygen/compound_since/namespaces.html
+++ b/documentation/test_doxygen/compound_since/namespaces.html
@@ -36,7 +36,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Namespaces</h2>
+        <h1>Namespaces</h1>
         <ul class="m-doc">
           <li>namespace <a href="namespaceDeprecatedFoo.html" class="m-doc">DeprecatedFoo</a> <span class="m-label m-danger">deprecated since 2010.02</span> <span class="m-doc">A namespace.</span></li>
           <li>namespace <a href="namespaceFoo.html" class="m-doc">Foo</a> <a href="changelog.html#changelog-2010-02" class="m-label m-success m-flat">since 2010.02</a> <span class="m-doc">A namespace.</span></li>

--- a/documentation/test_doxygen/compound_since/pages.html
+++ b/documentation/test_doxygen/compound_since/pages.html
@@ -36,7 +36,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           <li><a href="a.html" class="m-doc">This is new.</a> <a href="changelog.html#changelog-2019-11" class="m-label m-success m-flat">since 2019.11</a> <span class="m-doc"></span></li>
           <li><a href="deprecated-a.html" class="m-doc">This is old.</a> <span class="m-label m-danger">deprecated since 2010.02</span> <span class="m-doc"></span></li>

--- a/documentation/test_doxygen/cpp_derived/annotated.html
+++ b/documentation/test_doxygen/cpp_derived/annotated.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">namespace</a> <a href="namespaceAnother.html" class="m-doc">Another</a> <span class="m-doc">Another namespace.</span>

--- a/documentation/test_doxygen/layout/pages.html
+++ b/documentation/test_doxygen/layout/pages.html
@@ -64,7 +64,7 @@
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
         <p><a href="pages.html">A self link</a>.</p>
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
         </ul>
         <script>

--- a/documentation/test_doxygen/page_brief/pages.html
+++ b/documentation/test_doxygen/page_brief/pages.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           <li><a href="page-a.html" class="m-doc">A page</a> <span class="m-doc">Brief docs for a page.</span></li>
           <li><a href="page-b.html" class="m-doc">Page B</a> <span class="m-doc">Brief with a period.</span></li>

--- a/documentation/test_doxygen/page_empty_page/pages.html
+++ b/documentation/test_doxygen/page_empty_page/pages.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
         </ul>
         <script>

--- a/documentation/test_doxygen/page_order/pages.html
+++ b/documentation/test_doxygen/page_order/pages.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)"></a><a href="03-first.html" class="m-doc">First</a> <span class="m-doc"></span>

--- a/documentation/test_doxygen/page_subpage_of_index/pages.html
+++ b/documentation/test_doxygen/page_subpage_of_index/pages.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)"></a><a href="index.html" class="m-doc">My Project</a> <span class="m-doc"></span>

--- a/documentation/test_doxygen/undocumented/annotated.html
+++ b/documentation/test_doxygen/undocumented/annotated.html
@@ -41,7 +41,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">namespace</a> <a href="namespaceNamespace.html" class="m-doc">Namespace</a> <span class="m-doc"><span></span></span>

--- a/documentation/test_doxygen/undocumented/files.html
+++ b/documentation/test_doxygen/undocumented/files.html
@@ -41,7 +41,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Files</h2>
+        <h1>Files</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">dir</a> <a href="dir_4b0d5f8864bf89936129251a2d32609b.html" class="m-doc">Directory</a> <span class="m-doc"><span></span></span>

--- a/documentation/test_python/content/classes.html
+++ b/documentation/test_python/content/classes.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">module</a> <a href="content.html" class="m-doc">content</a> <span class="m-doc">This overwrites the docstring for <a class="m-doc" href="content.html">content</a>.</span>

--- a/documentation/test_python/inspect_string/classes.html
+++ b/documentation/test_python/inspect_string/classes.html
@@ -31,7 +31,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">module</a> <a href="inspect_string.html" class="m-doc">inspect_string</a> <span class="m-doc">A module</span>

--- a/documentation/test_python/inspect_string/modules.html
+++ b/documentation/test_python/inspect_string/modules.html
@@ -31,7 +31,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Modules</h2>
+        <h1>Modules</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">module</a> <a href="inspect_string.html" class="m-doc">inspect_string</a> <span class="m-doc">A module</span>

--- a/documentation/test_python/link_formatting/s.classes.html
+++ b/documentation/test_python/link_formatting/s.classes.html
@@ -44,7 +44,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Classes</h2>
+        <h1>Classes</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">module</a> <a href="m.link_formatting.html#this-is-an-url" class="m-doc">link_formatting</a> <span class="m-doc">This is a module.</span>

--- a/documentation/test_python/link_formatting/s.modules.html
+++ b/documentation/test_python/link_formatting/s.modules.html
@@ -44,7 +44,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Modules</h2>
+        <h1>Modules</h1>
         <ul class="m-doc">
           <li class="m-doc-collapsible">
             <a href="#" onclick="return toggle(this)">module</a> <a href="m.link_formatting.html#this-is-an-url" class="m-doc">link_formatting</a> <span class="m-doc">This is a module.</span>

--- a/documentation/test_python/link_formatting/s.pages.html
+++ b/documentation/test_python/link_formatting/s.pages.html
@@ -44,7 +44,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           <li><a href="p.page.html#this-is-an-url" class="m-doc">This is a page</a> <span class="m-doc"></span></li>
         </ul>

--- a/documentation/test_python/page/pages.html
+++ b/documentation/test_python/page/pages.html
@@ -19,7 +19,7 @@
   <div class="m-container m-container-inflatable">
     <div class="m-row">
       <div class="m-col-l-10 m-push-l-1">
-        <h1>Pages</h2>
+        <h1>Pages</h1>
         <ul class="m-doc">
           <li><a href="another.html" class="m-doc">Another page</a> <span class="m-doc">Here's some summary. <strong>It's formated as well.</strong></span></li>
           <li><a href="error.html" class="m-doc">error.rst</a> <span class="m-doc"></span></li>


### PR DESCRIPTION
There is a typo in closing `h1` tag, e.g.:
```html
        <h1>Classes</h2>
```
