### PR TITLE
Fix search input focus loose on autocompletion by tab

### DIFF
--- a/documentation/search.js
+++ b/documentation/search.js
@@ -666,8 +666,10 @@ if(typeof document !== 'undefined') {
             } else if(event.key == 'Tab' && !event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey) {
                 /* But only if the input has selection at the end */
                 let input = document.getElementById('search-input');
-                if(input.selectionEnd == input.value.length && input.selectionStart != input.selectionEnd)
+                if(input.selectionEnd == input.value.length && input.selectionStart != input.selectionEnd){
                     input.setSelectionRange(input.value.length, input.value.length);
+                    return false; /* so input won't loose focus */
+                }
 
             /* Select next item */
             } else if(event.key == 'ArrowDown') {


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/2975991/85959894-ede36080-b9a7-11ea-966a-da64bd31a1c2.gif)


After:
![after](https://user-images.githubusercontent.com/2975991/85959899-efad2400-b9a7-11ea-8a04-c1b80b7bbf66.gif)