### PR TITLE
Use full pybind11 docstrings

### DIFF
--- a/documentation/python.py
+++ b/documentation/python.py
@@ -918,17 +918,17 @@ def parse_pybind_signature(state: State, referrer_path: List[str], signature: st
         end = original_signature.find('\n')
         logging.warning("cannot parse pybind11 function signature %s", original_signature[:end if end != -1 else None])
         if end != -1 and len(original_signature) > end + 1 and original_signature[end + 1] == '\n':
-            summary = inspect.cleandoc(original_signature[end + 1:]).partition('\n\n')[0]
+            docstring = inspect.cleandoc(original_signature[end + 1:])
         else:
-            summary = ''
-        return (name, summary, [('…', None, None, None)], None, None)
+            docstring = ''
+        return (name, docstring, [('…', None, None, None)], None, None)
 
     if len(signature) > 1 and signature[1] == '\n':
-        summary = inspect.cleandoc(signature[2:]).partition('\n\n')[0]
+        docstring = inspect.cleandoc(signature[2:])
     else:
-        summary = ''
+        docstring = ''
 
-    return (name, summary, args, return_type, return_type_link)
+    return (name, docstring, args, return_type, return_type_link)
 
 def parse_pybind_docstring(state: State, referrer_path: List[str], doc: str) -> List[Tuple[str, str, List[Tuple[str, str, str]], str]]:
     name = referrer_path[-1]

--- a/documentation/test_python/CMakeLists.txt
+++ b/documentation/test_python/CMakeLists.txt
@@ -61,3 +61,9 @@ pybind11_add_module(pybind_submodules_package pybind_submodules_package/sub.cpp)
 set_target_properties(pybind_submodules_package PROPERTIES
     OUTPUT_NAME sub
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/pybind_submodules_package/pybind_submodules_package)
+
+# Need a special name for this one
+pybind11_add_module(pybind_docstrings pybind_docstrings/pybind_docstrings.cpp)
+set_target_properties(pybind_docstrings PROPERTIES
+    OUTPUT_NAME pybind_docstrings
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/pybind_docstrings)

--- a/documentation/test_python/pybind_docstrings/pybind_docstrings.cpp
+++ b/documentation/test_python/pybind_docstrings/pybind_docstrings.cpp
@@ -1,0 +1,43 @@
+#include <functional>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h> /* needed for std::vector! */
+#include <pybind11/functional.h> /* for std::function */
+
+namespace py = pybind11;
+
+int scale(int a, float argument) {
+    return int(a*argument);
+}
+
+PYBIND11_MODULE(pybind_docstrings, m) {
+    m.doc() = "pybind11 function signature extraction";
+
+    m
+        .def("scale_kwargs", &scale, R"(Scale an integer, kwargs
+
+    :param a: An integer
+    :param argument: Scale factor
+    :return: Scaled integer
+
+    Here is a usage examples:
+
+    >>> scale_kwargs(a=10, argument=1.63)
+    16
+
+    >>> scale_kwargs(a=3, argument=2.9)
+    8
+
+        )", py::arg("a"), py::arg("argument"))
+        .def("scale_kwargs", [](int a){ return scale(a, 10); }, R"(Scale integer by 10
+
+
+
+    :param a: An integer to scale by 10
+    :return: Scaled integer
+
+    Here is a usage example:
+
+    >>> scale_kwargs(a=10)
+    100
+        )", py::arg("a"));
+}

--- a/documentation/test_python/pybind_docstrings/pybind_docstrings.html
+++ b/documentation/test_python/pybind_docstrings/pybind_docstrings.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>pybind_docstrings | My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>
+          pybind_docstrings <span class="m-thin">module</span>
+        </h1>
+        <p>pybind11 function signature extraction</p>
+        <div class="m-block m-default">
+          <h3>Contents</h3>
+          <ul>
+            <li>
+              Reference
+              <ul>
+                <li><a href="#functions">Functions</a></li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+        <section id="functions">
+          <h2><a href="#functions">Functions</a></h2>
+          <dl class="m-doc">
+            <dt>
+              <span class="m-doc-wrap-bumper">def <a href="#scale_kwargs-8f19c" class="m-doc">scale_kwargs</a>(</span><span class="m-doc-wrap">a: int,
+              argument: float) -&gt; int</span>
+            </dt>
+            <dd>Scale an integer, kwargs</dd>
+            <dt>
+              <span class="m-doc-wrap-bumper">def <a href="#scale_kwargs-46f8a" class="m-doc">scale_kwargs</a>(</span><span class="m-doc-wrap">a: int) -&gt; int</span>
+            </dt>
+            <dd>Scale integer by 10</dd>
+          </dl>
+        </section>
+        <section>
+          <h2>Function documentation</h2>
+          <section class="m-doc-details" id="scale_kwargs-8f19c"><div>
+            <h3>
+              <span class="m-doc-wrap-bumper">def pybind_docstrings.<wbr /></span><span class="m-doc-wrap"><span class="m-doc-wrap-bumper"><a href="#scale_kwargs-8f19c" class="m-doc-self">scale_kwargs</a>(</span><span class="m-doc-wrap">a: int,
+              argument: float) -&gt; int</span></span>
+            </h3>
+            <p>Scale an integer, kwargs</p>
+            <table class="m-table m-fullwidth m-flat">
+              <thead>
+                <tr><th colspan="2">Parameters</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td style="width: 1%">a</td>
+                  <td>An integer</td>
+                </tr>
+                <tr>
+                  <td>argument</td>
+                  <td>Scale factor</td>
+                </tr>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <th>Returns</th>
+                  <td>Scaled integer</td>
+                </tr>
+              </tfoot>
+            </table>
+<p>Here is a usage examples:</p>
+<pre class="code python doctest">&gt;&gt;&gt; scale_kwargs(a=10, argument=1.63)
+16
+</pre>
+<pre class="code python doctest">&gt;&gt;&gt; scale_kwargs(a=3, argument=2.9)
+8
+</pre>
+          </div></section>
+          <section class="m-doc-details" id="scale_kwargs-46f8a"><div>
+            <h3>
+              <span class="m-doc-wrap-bumper">def pybind_docstrings.<wbr /></span><span class="m-doc-wrap"><span class="m-doc-wrap-bumper"><a href="#scale_kwargs-46f8a" class="m-doc-self">scale_kwargs</a>(</span><span class="m-doc-wrap">a: int) -&gt; int</span></span>
+            </h3>
+            <p>Scale integer by 10</p>
+<p>Here is a usage example:</p>
+<pre class="code python doctest">&gt;&gt;&gt; scale_kwargs(a=10)
+100
+</pre>
+          </div></section>
+        </section>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/test_pybind.py
+++ b/documentation/test_python/test_pybind.py
@@ -304,6 +304,29 @@ class Signatures(BaseInspectTestCase):
         if pybind_signatures.MyClass23.is_pybind23:
             self.assertEqual(*self.actual_expected_contents('pybind_signatures.MyClass23.html'))
 
+class Docstrings(BaseInspectTestCase):
+
+    def test_doctest(self):
+        if self.path not in sys.path:
+            sys.path.append(self.path)
+        import doctest
+        import pybind_docstrings
+        failure_count, test_count = doctest.testmod(pybind_docstrings)
+        assert failure_count == 0
+
+    def test_page_generation(self):
+        if self.path not in sys.path:
+            sys.path.append(self.path)
+        import pybind_docstrings
+        self.run_python({
+            'INPUT_MODULES': [pybind_docstrings],
+            'PYBIND11_COMPATIBILITY': True,
+            'M_SPHINX_PARSE_DOCSTRINGS': True,
+            'PLUGINS': ['m.sphinx']
+        })
+
+        self.assertEqual(*self.actual_expected_contents('pybind_docstrings.html'))
+
 class Enums(BaseInspectTestCase):
     def test(self):
         self.run_python({


### PR DESCRIPTION
Pybind11 docstrings were limited to first paragraph and rest was stripped, this PR fixes that.

<details><summary>Test page render</summary>

![image](https://user-images.githubusercontent.com/2975991/86127546-bc25e300-bae8-11ea-8e59-be9d17e8d167.png)

</details>