### PR TITLE
Exceptions in separate section

### DIFF
--- a/doc/documentation/python.rst
+++ b/doc/documentation/python.rst
@@ -1162,6 +1162,9 @@ Property                                Description
                                         `Function properties`_ for details.
 :py:`page.methods`                      List of methods. See
                                         `Function properties`_ for details.
+:py:`page.exceptions`                   List of exceptions, does not overlap
+                                        with py:`page.classes`. See
+                                        `Class properties`_ for details.
 :py:`page.dunder_methods`               List of double-underscored special
                                         functions. See
                                         `Function properties`_ for details.
@@ -1199,6 +1202,7 @@ Property                                Description
 ======================================= =======================================
 :py:`class_.url`                        URL of detailed class documentation
 :py:`class_.name`                       Class name
+:py:`class_.is_exception`               Marks exceptions
 :py:`class_.summary`                    Doc summary
 ======================================= =======================================
 
@@ -1396,7 +1400,8 @@ The form of each list entry is the same:
 Property                        Description
 =============================== ===============================================
 :py:`i.kind`                    Entry kind (one of :py:`'module'`,
-                                :py:`'class'` or :py:`'page'`)
+                                :py:`'class'`, :py:`'exception'` or
+                                :py:`'page'`)
 :py:`i.name`                    Name
 :py:`i.url`                     URL of the file with detailed documentation
 :py:`i.summary`                 Doc summary

--- a/documentation/python.py
+++ b/documentation/python.py
@@ -398,6 +398,7 @@ def crawl_class(state: State, path: List[str], class_):
     class_entry.type = EntryType.CLASS
     class_entry.object = class_
     class_entry.path = path
+    class_entry.is_exception = issubclass(class_, BaseException)
     class_entry.css_classes = ['m-doc']
     class_entry.url = state.config['URL_FORMATTER'](EntryType.CLASS, path)[1]
     class_entry.members = []
@@ -1264,6 +1265,7 @@ def extract_class_doc(state: State, entry: Empty):
     out = Empty()
     out.url = entry.url
     out.name = entry.path[-1]
+    out.is_exception = entry.is_exception
     out.summary = extract_docs(state, state.class_docs, entry.type, entry.path, entry.object.__doc__, summary_only=True)
 
     # Call all scope exit hooks last
@@ -1913,6 +1915,7 @@ def render_module(state: State, path, module, env):
     page.enums = []
     page.functions = []
     page.data = []
+    page.exceptions = []
     page.has_enum_details = False
     page.has_function_details = False
     page.has_data_details = False
@@ -1933,7 +1936,11 @@ def render_module(state: State, path, module, env):
         if member_entry.type == EntryType.MODULE:
             page.modules += [extract_module_doc(state, member_entry)]
         elif member_entry.type == EntryType.CLASS:
-            page.classes += [extract_class_doc(state, member_entry)]
+            doc_ = extract_class_doc(state, member_entry)
+            if doc_.is_exception:
+                page.exceptions += [doc_]
+            else:
+                page.classes += [doc_]
         elif member_entry.type == EntryType.ENUM:
             enum_ = extract_enum_doc(state, member_entry)
             page.enums += [enum_]
@@ -2004,6 +2011,7 @@ def render_class(state: State, path, class_, env):
     page.methods = []
     page.properties = []
     page.data = []
+    page.exceptions = []
     page.has_enum_details = False
     page.has_function_details = False
     page.has_property_details = False
@@ -2024,7 +2032,11 @@ def render_class(state: State, path, class_, env):
             logging.warning("%s is undocumented", subpath_str)
 
         if member_entry.type == EntryType.CLASS:
-            page.classes += [extract_class_doc(state, member_entry)]
+            doc_ = extract_class_doc(state, member_entry)
+            if doc_.is_exception:
+                page.exceptions += [doc_]
+            else:
+                page.classes += [doc_]
         elif member_entry.type == EntryType.ENUM:
             enum_ = extract_enum_doc(state, member_entry)
             page.enums += [enum_]
@@ -2547,7 +2559,7 @@ def run(basedir, config, *, templates=default_templates, search_add_lookahead_ba
     # from the top-level index list and gather all class/module children.
     def fetch_class_index(entry):
         index_entry = Empty()
-        index_entry.kind = 'module' if entry.type == EntryType.MODULE else 'class'
+        index_entry.kind = 'module' if entry.type == EntryType.MODULE else ('exception' if entry.is_exception else 'class')
         index_entry.name = entry.path[-1]
         index_entry.url = state.config['URL_FORMATTER'](entry.type, entry.path)[1]
         index_entry.summary = entry.summary

--- a/documentation/templates/python/class.html
+++ b/documentation/templates/python/class.html
@@ -15,7 +15,7 @@
 
 {% block main %}
         <h1>
-          {%+ for name, target in page.breadcrumb[:-1] %}<span class="m-breadcrumb"><a href="{{ target }}">{{ name }}</a>.<wbr/></span>{% endfor %}{{ page.breadcrumb[-1][0] }} <span class="m-thin">class</span>
+          {%+ for name, target in page.breadcrumb[:-1] %}<span class="m-breadcrumb"><a href="{{ target }}">{{ name }}</a>.<wbr/></span>{% endfor %}{{ page.breadcrumb[-1][0] }} <span class="m-thin">{% if page.is_exception %}exception{% else %}class{% endif %}</span>
         </h1>
         {% if page.summary %}
         <p>{{ page.summary }}</p>
@@ -50,6 +50,9 @@
                 {% endif %}
                 {% if page.data %}
                 <li><a href="#data">Data</a></li>
+                {% endif %}
+                {% if page.exceptions %}
+                <li><a href="#exceptions">Exceptions</a></li>
                 {% endif %}
               </ul>
             </li>
@@ -135,6 +138,16 @@
           <dl class="m-doc">
             {% for data in page.data %}
 {{ entry_data(data) }}
+            {% endfor %}
+          </dl>
+        </section>
+        {% endif %}
+        {% if page.exceptions %}
+        <section id="exceptions">
+          <h2><a href="#exceptions">Exceptions</a></h2>
+          <dl class="m-doc">
+            {% for exception in page.exceptions %}
+{{ entry_class(exception) }}
             {% endfor %}
           </dl>
         </section>

--- a/documentation/templates/python/entry-class.html
+++ b/documentation/templates/python/entry-class.html
@@ -1,2 +1,2 @@
-            <dt>class <a href="{{ class.url }}" class="m-doc">{{ class.name }}</a>{% if class.is_deprecated %} <span class="m-label m-danger">deprecated</span>{% endif %}</dt>
+            <dt>{%if class.is_exception%}exception{%else%}class{%endif%} <a href="{{ class.url }}" class="m-doc">{{ class.name }}</a>{% if class.is_deprecated %} <span class="m-label m-danger">deprecated</span>{% endif %}</dt>
             <dd>{{ class.summary }}</dd>

--- a/documentation/templates/python/module.html
+++ b/documentation/templates/python/module.html
@@ -41,6 +41,9 @@
                 {% if page.data %}
                 <li><a href="#data">Data</a></li>
                 {% endif %}
+                {% if page.exceptions %}
+                <li><a href="#exceptions">Exceptions</a></li>
+                {% endif %}
               </ul>
             </li>
           </ul>
@@ -95,6 +98,16 @@
           <dl class="m-doc">
             {% for data in page.data %}
 {{ entry_data(data) }}
+            {% endfor %}
+          </dl>
+        </section>
+        {% endif %}
+        {% if page.exceptions %}
+        <section id="exceptions">
+          <h2><a href="#exceptions">Exceptions</a></h2>
+          <dl class="m-doc">
+            {% for exception in page.exceptions %}
+{{ entry_class(exception) }}
             {% endfor %}
           </dl>
         </section>

--- a/documentation/test_python/content/classes.html
+++ b/documentation/test_python/content/classes.html
@@ -26,10 +26,16 @@
             <ul class="m-doc">
               <li>module <a href="content.docstring_summary.html" class="m-doc">docstring_summary</a> <span class="m-doc">This module retains summary from the docstring</span></li>
               <li>module <a href="content.submodule.html" class="m-doc">submodule</a> <span class="m-doc">This submodule has an external summary.</span></li>
-              <li>class <a href="content.Class.html" class="m-doc">Class</a> <span class="m-doc">This overwrites the docstring for <a class="m-doc" href="content.Class.html">Class</a>.</span></li>
+              <li class="m-doc-collapsible collapsed">
+                <a href="#" onclick="return toggle(this)">class</a> <a href="content.Class.html" class="m-doc">Class</a> <span class="m-doc">This overwrites the docstring for <a class="m-doc" href="content.Class.html">Class</a>.</span>
+                <ul class="m-doc">
+                  <li>exception <a href="content.Class.ClassError.html" class="m-doc">ClassError</a> <span class="m-doc">This exception belongs to class</span></li>
+                </ul>
+              </li>
               <li>class <a href="content.ClassDocumentingItsMembers.html" class="m-doc">ClassDocumentingItsMembers</a> <span class="m-doc">This class documents its members directly in its own directive</span></li>
               <li>class <a href="content.ClassWithSlots.html" class="m-doc">ClassWithSlots</a> <span class="m-doc">This class has slots and those have to be documented externally</span></li>
               <li>class <a href="content.ClassWithSummary.html" class="m-doc">ClassWithSummary</a> <span class="m-doc">This class has summary from the docstring</span></li>
+              <li>exception <a href="content.FreeStandingError.html" class="m-doc">FreeStandingError</a> <span class="m-doc">This exception belongs to module</span></li>
             </ul>
           </li>
         </ul>

--- a/documentation/test_python/content/content.Class.html
+++ b/documentation/test_python/content/content.Class.html
@@ -35,6 +35,7 @@
                 <li><a href="#dunder-methods">Special methods</a></li>
                 <li><a href="#properties">Properties</a></li>
                 <li><a href="#data">Data</a></li>
+                <li><a href="#exceptions">Exceptions</a></li>
               </ul>
             </li>
           </ul>
@@ -120,6 +121,13 @@ detail view</dd>
               <a href="#DATA_WITH_DETAILS" class="m-doc">DATA_WITH_DETAILS</a>: str = &#x27;this blows&#x27;
             </dt>
             <dd></dd>
+          </dl>
+        </section>
+        <section id="exceptions">
+          <h2><a href="#exceptions">Exceptions</a></h2>
+          <dl class="m-doc">
+            <dt>exception <a href="content.Class.ClassError.html" class="m-doc">ClassError</a></dt>
+            <dd>This exception belongs to class</dd>
           </dl>
         </section>
         <section>

--- a/documentation/test_python/content/content.html
+++ b/documentation/test_python/content/content.html
@@ -34,6 +34,7 @@
                 <li><a href="#enums">Enums</a></li>
                 <li><a href="#functions">Functions</a></li>
                 <li><a href="#data">Data</a></li>
+                <li><a href="#exceptions">Exceptions</a></li>
               </ul>
             </li>
           </ul>
@@ -145,6 +146,13 @@ add any detailed block.</dd>
               <a href="#DATA_WITH_DETAILS_BUT_NO_SUMMARY_NEITHER_TYPE" class="m-doc">DATA_WITH_DETAILS_BUT_NO_SUMMARY_NEITHER_TYPE</a> = None
             </dt>
             <dd></dd>
+          </dl>
+        </section>
+        <section id="exceptions">
+          <h2><a href="#exceptions">Exceptions</a></h2>
+          <dl class="m-doc">
+            <dt>exception <a href="content.FreeStandingError.html" class="m-doc">FreeStandingError</a></dt>
+            <dd>This exception belongs to module</dd>
           </dl>
         </section>
         <section>

--- a/documentation/test_python/content/content/__init__.py
+++ b/documentation/test_python/content/content/__init__.py
@@ -48,6 +48,12 @@ class Class:
 
     DATA_WITH_DETAILS: str = 'this blows'
 
+    class ClassError(RuntimeError):
+        """This exception belongs to class"""
+
+class FreeStandingError(RuntimeError):
+    """This exception belongs to module"""
+
 class ClassWithSummary:
     """This class has summary from the docstring"""
 

--- a/documentation/test_python/inspect_string/classes.html
+++ b/documentation/test_python/inspect_string/classes.html
@@ -43,7 +43,7 @@
                   <li>class <a href="inspect_string.subpackage.Foo.html" class="m-doc">Foo</a> <span class="m-doc">A class in a subpackage. Shouldn&#x27;t cause the module tree to have an expander for it.</span></li>
                 </ul>
               </li>
-              <li>class <a href="inspect_string.DerivedException.html" class="m-doc">DerivedException</a> <span class="m-doc">A class deriving from BaseException, which has the weird args getset_descriptor</span></li>
+              <li>exception <a href="inspect_string.DerivedException.html" class="m-doc">DerivedException</a> <span class="m-doc">A class deriving from BaseException, which has the weird args getset_descriptor</span></li>
               <li class="m-doc-collapsible collapsed">
                 <a href="#" onclick="return toggle(this)">class</a> <a href="inspect_string.Foo.html" class="m-doc">Foo</a> <span class="m-doc">The foo class</span>
                 <ul class="m-doc">

--- a/documentation/test_python/inspect_string/inspect_string.html
+++ b/documentation/test_python/inspect_string/inspect_string.html
@@ -46,6 +46,7 @@
                 <li><a href="#enums">Enums</a></li>
                 <li><a href="#functions">Functions</a></li>
                 <li><a href="#data">Data</a></li>
+                <li><a href="#exceptions">Exceptions</a></li>
               </ul>
             </li>
           </ul>
@@ -62,8 +63,6 @@
         <section id="classes">
           <h2><a href="#classes">Classes</a></h2>
           <dl class="m-doc">
-            <dt>class <a href="inspect_string.DerivedException.html" class="m-doc">DerivedException</a></dt>
-            <dd>A class deriving from BaseException, which has the weird args getset_descriptor</dd>
             <dt>class <a href="inspect_string.Foo.html" class="m-doc">Foo</a></dt>
             <dd>The foo class</dd>
             <dt>class <a href="inspect_string.FooSlots.html" class="m-doc">FooSlots</a></dt>
@@ -108,6 +107,13 @@
               <a href="#foo" class="m-doc-self">foo</a>
             </dt>
             <dd></dd>
+          </dl>
+        </section>
+        <section id="exceptions">
+          <h2><a href="#exceptions">Exceptions</a></h2>
+          <dl class="m-doc">
+            <dt>exception <a href="inspect_string.DerivedException.html" class="m-doc">DerivedException</a></dt>
+            <dd>A class deriving from BaseException, which has the weird args getset_descriptor</dd>
           </dl>
         </section>
         <section>


### PR DESCRIPTION
This PR splits `Classes` section in two: `Classes` and `Exceptions`.