### PR TITLE
Always set param.type to a valid string

### DIFF
--- a/documentation/doxygen.py
+++ b/documentation/doxygen.py
@@ -2020,7 +2020,7 @@ def parse_func(state: State, element: ET.Element):
         name = p.find('declname')
         param = Empty()
         param.name = name.text if name is not None else ''
-        param.type = parse_type(state, p.find('type'))
+        param.type = parse_type(state, p.find('type')) or ''
 
         # Recombine parameter name and array information back
         array = p.find('array')


### PR DESCRIPTION
Hi and thanks for this great theme! We're currently working on using `m.css` with Doxygen in the [ModernCppStarter](https://github.com/TheLartians/ModernCppStarter) project as it's a great improvement to the standard Doxygen output.

While adding support, I've noticed that the `doxygen.py` script can crash under certain conditions (specifically when `M_SHOW_UNDOCUMENTED` is set), as the script assumes `param.type` to be a valid string. However, as `parse_type()` returns either a string or `None`, this is not always the case.

This PR will fallback to an empty string when `parse_type()` returns `None`.