### PR TITLE
Fix doxygen base path resolution

### DIFF
--- a/documentation/doxygen.py
+++ b/documentation/doxygen.py
@@ -3354,7 +3354,10 @@ def parse_index_xml(state: State, xml):
     return parsed
 
 def parse_doxyfile(state: State, doxyfile, values = None):
-    state.basedir = os.path.dirname(doxyfile)
+    
+    # Use top-level doxyfile path as base
+    if not state.basedir: 
+        state.basedir = os.path.dirname(doxyfile)
 
     logging.debug("Parsing configuration from {}".format(doxyfile))
 


### PR DESCRIPTION
Use top-level doxygen path as base path. In case of recursive descent, don't allow base path to be overriden.