### PR TITLE
Fix import errors in plugins

### DIFF
--- a/plugins/m/alias.py
+++ b/plugins/m/alias.py
@@ -74,6 +74,6 @@ def register_mcss(**kwargs):
 def _pelican_get_generators(generators): return AliasGenerator
 
 def register(): # for Pelican
-    import pelican.signals
+    from pelican import signals
 
-    pelican.signals.get_generators.connect(_pelican_get_generators)
+    signals.get_generators.connect(_pelican_get_generators)

--- a/plugins/m/code.py
+++ b/plugins/m/code.py
@@ -323,6 +323,6 @@ def _pelican_configure(pelicanobj):
     register_mcss(mcss_settings=settings)
 
 def register(): # for Pelican
-    import pelican.signals
+    from pelican import signals
 
-    pelican.signals.initialized.connect(_pelican_configure)
+    signals.initialized.connect(_pelican_configure)

--- a/plugins/m/dot.py
+++ b/plugins/m/dot.py
@@ -117,6 +117,6 @@ def _pelican_configure(pelicanobj):
     register_mcss(mcss_settings=pelicanobj.settings)
 
 def register(): # for Pelican
-    import pelican.signals
+    from pelican import signals
 
-    pelican.signals.initialized.connect(_pelican_configure)
+    signals.initialized.connect(_pelican_configure)

--- a/plugins/m/dox.py
+++ b/plugins/m/dox.py
@@ -187,6 +187,6 @@ def _pelican_configure(pelicanobj):
     register_mcss(mcss_settings=settings)
 
 def register(): # for Pelican
-    import pelican.signals
+    from pelican import signals
 
-    pelican.signals.initialized.connect(_pelican_configure)
+    signals.initialized.connect(_pelican_configure)

--- a/plugins/m/filesize.py
+++ b/plugins/m/filesize.py
@@ -75,6 +75,6 @@ def _pelican_configure(pelicanobj):
     register_mcss(mcss_settings=settings)
 
 def register(): # for Pelican
-    import pelican.signals
+    from pelican import signals
 
-    pelican.signals.initialized.connect(_pelican_configure)
+    signals.initialized.connect(_pelican_configure)

--- a/plugins/m/htmlsanity.py
+++ b/plugins/m/htmlsanity.py
@@ -730,7 +730,7 @@ def register_mcss(mcss_settings, jinja_environment, **kwargs):
 # Below is only Pelican-specific functionality. If Pelican is not found, these
 # do nothing.
 try:
-    import pelican.signals
+    from pelican import signals
     from pelican.readers import RstReader
 
     class PelicanSaneRstReader(RstReader):
@@ -800,5 +800,5 @@ def _pelican_add_reader(readers):
     readers.reader_classes['rst'] = PelicanSaneRstReader
 
 def register(): # for Pelican
-    pelican.signals.initialized.connect(_pelican_configure)
-    pelican.signals.readers_init.connect(_pelican_add_reader)
+    signals.initialized.connect(_pelican_configure)
+    signals.readers_init.connect(_pelican_add_reader)

--- a/plugins/m/images.py
+++ b/plugins/m/images.py
@@ -309,6 +309,6 @@ def _pelican_configure(pelicanobj):
     register_mcss(mcss_settings=settings)
 
 def register(): # for Pelican
-    import pelican.signals
+    from pelican import signals
 
-    pelican.signals.initialized.connect(_pelican_configure)
+    signals.initialized.connect(_pelican_configure)

--- a/plugins/m/math.py
+++ b/plugins/m/math.py
@@ -164,8 +164,8 @@ def _configure_pelican(pelicanobj):
     register_mcss(mcss_settings=pelicanobj.settings, hooks_pre_page=[], hooks_post_run=[])
 
 def register():
-    import pelican.signals
+    from pelican import signals
 
-    pelican.signals.initialized.connect(_configure_pelican)
-    pelican.signals.finalized.connect(save_cache)
-    pelican.signals.content_object_init.connect(new_page)
+    signals.initialized.connect(_configure_pelican)
+    signals.finalized.connect(save_cache)
+    signals.content_object_init.connect(new_page)

--- a/plugins/m/plots.py
+++ b/plugins/m/plots.py
@@ -309,7 +309,7 @@ def _pelican_configure(pelicanobj):
     register_mcss(mcss_settings=pelicanobj.settings, hooks_pre_page=[])
 
 def register(): # for Pelican
-    import pelican.signals
+    from pelican import signals
 
-    pelican.signals.initialized.connect(_pelican_configure)
-    pelican.signals.content_object_init.connect(new_page)
+    signals.initialized.connect(_pelican_configure)
+    signals.content_object_init.connect(new_page)

--- a/plugins/m/sphinx.py
+++ b/plugins/m/sphinx.py
@@ -658,13 +658,13 @@ def _pelican_configure(pelicanobj):
          inventories=pelicanobj.settings.get('M_SPHINX_INVENTORIES', []))
 
 def register(): # for Pelican
-    import pelican.signals
+    from pelican import signals
 
     rst.roles.register_local_role('ref', ref)
 
-    pelican.signals.initialized.connect(_pelican_configure)
-    pelican.signals.article_generator_preread.connect(_pelican_new_page)
-    pelican.signals.page_generator_preread.connect(_pelican_new_page)
+    signals.initialized.connect(_pelican_configure)
+    signals.article_generator_preread.connect(_pelican_new_page)
+    signals.page_generator_preread.connect(_pelican_new_page)
 
 def pretty_print_intersphinx_inventory(file):
     return ''.join([


### PR DESCRIPTION
Related issues: #178, https://github.com/getpelican/pelican/issues/2805

Since there are two seperate issues with Pelican 4.5.0 (one about `import pelican.signals` and the other about `PLUGINS += ['m.htmlsanity']`), I will open a new issue for the latter.