### PR TITLE
Change m.css transitions into Docutils transition nodes.

### DIFF
--- a/plugins/m/components.py
+++ b/plugins/m/components.py
@@ -35,7 +35,7 @@ class Transition(rst.Directive):
     def run(self):
         text = ' '.join(self.arguments)
         title_nodes, _ = self.state.inline_text(text, self.lineno)
-        transition_node = nodes.paragraph('', '', *title_nodes)
+        transition_node = nodes.transition('', *title_nodes)
         transition_node['classes'] += ['m-transition']
         return [transition_node]
 

--- a/plugins/m/htmlsanity.py
+++ b/plugins/m/htmlsanity.py
@@ -635,7 +635,10 @@ class SaneHtmlTranslator(HTMLTranslator):
 
     # no class="docutils" in <hr>
     def visit_transition(self, node):
-        self.body.append(self.emptytag(node, 'hr'))
+        if 'm-transition' in node['classes']:
+            self.body.append(self.starttag(node, 'p', ''))
+        else:
+            self.body.append(self.emptytag(node, 'hr'))
 
     def depart_transition(self, node):
         pass

--- a/plugins/m/htmlsanity.py
+++ b/plugins/m/htmlsanity.py
@@ -635,7 +635,7 @@ class SaneHtmlTranslator(HTMLTranslator):
 
     # no class="docutils" in <hr>
     def visit_transition(self, node):
-        if 'm-transition' in node['classes']:
+        if len(node.children) > 0:
             self.body.append(self.starttag(node, 'p', ''))
         else:
             self.body.append(self.emptytag(node, 'hr'))

--- a/plugins/m/htmlsanity.py
+++ b/plugins/m/htmlsanity.py
@@ -641,7 +641,8 @@ class SaneHtmlTranslator(HTMLTranslator):
             self.body.append(self.emptytag(node, 'hr'))
 
     def depart_transition(self, node):
-        pass
+        if 'm-transition' in node['classes']:
+            self.body.append('</p>\n')
 
 class _SaneFieldBodyTranslator(SaneHtmlTranslator):
     """


### PR DESCRIPTION
Among others, this allows transitions at the end of a section to be moved one level up in the tree and after the section, similarly to how reST transitions are handled by Docutils.

While I didn't try building the site like the contributing guidelines say, a quick search for usages of the `.. transition::` directive indicates that there should be no issues. 😅 