### PR TITLE
Suggested fix for #206: processing error on doxygen 1.9.x XML output

### DIFF
--- a/documentation/doxygen.py
+++ b/documentation/doxygen.py
@@ -2192,6 +2192,11 @@ def extract_metadata(state: State, xml):
 
     compounddef: ET.Element = root.find('compounddef')
 
+    # Skip XML-files without metadata (e.g. doxygen 1.9.x's Doxyfile.xml)
+    if compounddef is None:
+        logging.debug("No metadata found in {}, skipping".format(os.path.basename(xml)))
+        return
+
     if compounddef.attrib['kind'] not in ['namespace', 'group', 'class', 'struct', 'union', 'dir', 'file', 'page']:
         logging.debug("No useful info in {}, skipping".format(os.path.basename(xml)))
         return
@@ -2454,10 +2459,14 @@ def parse_xml(state: State, xml: str):
         return
 
     root = tree.getroot()
-    assert root.tag == 'doxygen'
+    if root.tag != 'doxygen':
+        logging.debug("Root element is '{}' but should be 'doxygen', skipping".format(root.tag))
+        return
 
     compounddef: ET.Element = root[0]
-    assert compounddef.tag == 'compounddef'
+    if compounddef.tag != 'compounddef':
+        logging.debug("First child element is '{}' but should be 'compounddef', skipping".format(compounddef.tag))
+        return
     assert len([i for i in root]) == 1
 
     # Ignoring private structs/classes and unnamed namespaces


### PR DESCRIPTION
Doxygen since 1.9.x outputs an XML-file "Doxyfile.xml" whose root element is "doxyfile" (instead of "doxygen") and its schema info refers to "doxyfile.xsd" (instead of "compound.xsd). The root element has no "compounddef" element as first child.

AFAIR this breaks m-css's document compilation with doxygen 1.9.x.

m-css processes every XML-file in doxygen's output directory by name-globbing, regardless of the file's name or content. (I did not test it but I would expect the current processing to fail if any deviating XML files are added in the directory.)

`extract_metadata()` assumes that each XML-file contains an element 'compounddef' and fails otherwise (except for index.xml, which is explicitly checked for).

Two assertions would also fail in `parse_xml()` if the root element of the parsed XML-file is not 'doxygen' or the file is not index.xml (or no 'compounddef' is present).

I would like to suggest that in case the input XML turns out to be unexpected, just discard the current file but proceed with the next input file.

The patch I would like to propose just replaces the two assertions in `parse_xml()` with a clause that just skips the current input file (at least this was the intention). I also added a similar skip-clause in `extract_metadata()` that just discards the input if no 'compounddef' element is present. This should also make it at least a little harder for m-css to fail just because of unexpected XML files in the doxygen output directory.

Proposes fix #206