### PR TITLE
documentation/python: make links to literal ellipses as well

### DIFF
--- a/documentation/python.py
+++ b/documentation/python.py
@@ -1191,10 +1191,14 @@ def extract_annotation(state: State, referrer_path: List[str], annotation) -> Tu
     elif isinstance(annotation, typing.TypeVar):
         return annotation.__name__, annotation.__name__
 
-    # Ellipsis -- print a literal `...`
-    # TODO: any chance to link this to python official docs?
+    # Ellipsis -- print a literal `...`, link to Ellipsis in python docs
     elif annotation is ...:
-        return '...', '...'
+        # TODO m.sphinx needs to have a special case to extract `...` from
+        # python.inv (which is a `std.term`, alongside generic stuff like
+        # "class", "py" etc. which we DON'T want to link to) and convert it to
+        # a link to Ellipsis, or alternatively pass Ellipsis here but make it
+        # display as a literal ...
+        return '...', make_name_link(state, referrer_path, 'Ellipsis')
 
     # If the annotation is from the typing module, it ... gets complicated. It
     # could be a "bracketed" type, in which case we want to recurse to its

--- a/documentation/test_python/inspect_type_links/inspect_type_links/second.py
+++ b/documentation/test_python/inspect_type_links/inspect_type_links/second.py
@@ -65,6 +65,9 @@ def type_string(a: 'Foo'):
 def type_nested(a: Tuple[Foo, List[Enum], Any]):
     """A function with nested type annotation"""
 
+def type_nested_ellipsis(a: Tuple[int, ...]):
+    """A function with a variadic tuple annotation"""
+
 def type_string_nested(a: 'Tuple[Foo, List[Enum], Any]'):
     """A function with string nested type annotation"""
 


### PR DESCRIPTION
If a literal `...` is in a type annotation, it should link to Python documentation like any other builtin type. TODOs:

- [ ] right now it's changed to a link that says Ellipsis instead of `...`, which isn't desired 
  - [ ] there has to be either some special-casing inside `m.sphinx` inventory parsing (but that'd have to narrow this patching down to just Python's own inventory, which is rather impossible to detect)
  - [ ] or there has to be e.g. an optional argument to `make_name_link()` that overrides the link title.
- [ ] the commit message has a silly typo