### PR TITLE
Browser-based presentation tool with a reST syntax and all m.css goodies

### DIFF
--- a/css/m-dark-presentation.compiled.css
+++ b/css/m-dark-presentation.compiled.css
@@ -3,7 +3,8 @@
 /*
     This file is part of m.css.
 
-    Copyright © 2017, 2018, 2019 Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2017, 2018, 2019, 2020, 2021, 2022, 2023
+              Vladimír Vondruš <mosra@centrum.cz>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -36,7 +37,7 @@ body { margin: 0; }
   margin-left: -1rem;
   margin-right: -1rem;
 }
-.m-row:after {
+.m-row::after {
   content: ' ';
   clear: both;
   display: table;
@@ -345,6 +346,7 @@ html {
 body {
   font-family: 'Source Sans Pro', sans-serif;
   font-size: 1rem;
+  line-height: normal;
   color: #dcdcdc;
 }
 h1, h2, h3, h4, h5, h6 {
@@ -390,23 +392,6 @@ hr {
 blockquote, hr {
   border-color: #405363;
 }
-pre {
-  font-family: 'Source Code Pro', monospace, monospace, monospace;
-  font-size: 0.9em;
-  padding: 0.5rem 1rem;
-  color: #e6e6e6;
-  background-color: #282e36;
-  border-radius: 0.2rem;
-  overflow-x: auto;
-  margin-top: 0;
-}
-pre.m-console-wrap {
-  white-space: pre-wrap;
-  word-break: break-all;
-}
-pre.m-console {
-  background-color: #161616;
-}
 strong, .m-text.m-strong { font-weight: bold; }
 em, .m-text.m-em { font-style: italic; }
 s, .m-text.m-s { text-decoration: line-through; }
@@ -438,15 +423,31 @@ mark {
   background-color: #c7cf2f;
   color: #2f83cc;
 }
-code {
+.m-link-wrap {
+  word-break: break-all;
+}
+pre, code {
   font-family: 'Source Code Pro', monospace, monospace, monospace;
   font-size: 0.9em;
-  padding: 0.125rem;
   color: #e6e6e6;
   background-color: #282e36;
 }
-code.m-console {
-  background-color: #161616;
+pre.m-console, code.m-console {
+  color: #e6e6e6;
+  background-color: #1a1c1d;
+}
+pre {
+  padding: 0.5rem 1rem;
+  border-radius: 0.2rem;
+  overflow-x: auto;
+  margin-top: 0;
+}
+pre.m-console-wrap {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+code {
+  padding: 0.125rem;
 }
 *:focus { outline-color: #5b9dd9; }
 div.m-scroll {
@@ -542,14 +543,15 @@ dl.m-diary:last-child {
 }
 dl.m-diary dt {
   font-weight: bold;
-  width: 3.5rem;
+  width: 6rem;
   float: left;
   clear: both;
   padding-top: 0.25rem;
 }
 dl.m-diary dd {
   padding-top: 0.25rem;
-  padding-left: 3.5rem;
+  padding-left: 6rem;
+  margin-left: 0;
 }
 a.m-footnote, dl.m-footnote dd span.m-footnote {
   top: -0.35rem;
@@ -764,7 +766,7 @@ table.m-table td.m-dim pre, table.m-table td.m-dim code,
 table.m-table th.m-dim pre, table.m-table th.m-dim code {
   background-color: rgba(34, 39, 46, 0.5);
 }
-img.m-image, svg.m-image {
+img.m-image, svg.m-image, video.m-image {
   display: block;
   margin-left: auto;
   margin-right: auto;
@@ -772,12 +774,18 @@ img.m-image, svg.m-image {
 div.m-image {
   text-align: center;
 }
-img.m-image, svg.m-image, div.m-image img, div.m-image svg {
+img.m-image, svg.m-image, video.m-image,
+div.m-image img, div.m-image svg, div.m-image video {
   max-width: 100%;
   border-radius: 0.2rem;
 }
-div.m-image.m-fullwidth img, div.m-image.m-fullwidth svg {
+div.m-image.m-fullwidth img,
+div.m-image.m-fullwidth svg,
+div.m-image.m-fullwidth video {
   width: 100%;
+}
+img.m-image.m-badge, div.m-image.m-badge img {
+  border-radius: 50%;
 }
 figure.m-figure {
   max-width: 100%;
@@ -787,7 +795,7 @@ figure.m-figure {
   position: relative;
   display: table;
 }
-figure.m-figure:before {
+figure.m-figure::before {
   position: absolute;
   content: ' ';
   top: 0;
@@ -800,7 +808,7 @@ figure.m-figure:before {
   border-radius: 0.2rem;
   border-color: #405363;
 }
-figure.m-figure.m-flat:before {
+figure.m-figure.m-flat::before {
   border-color: transparent;
 }
 figure.m-figure > * {
@@ -815,7 +823,9 @@ figure.m-figure > *:first-child {
 figure.m-figure > *:last-child {
   margin-bottom: 1rem !important;
 }
-figure.m-figure img, figure.m-figure svg {
+figure.m-figure img,
+figure.m-figure svg,
+figure.m-figure video {
   position: relative;
   margin-left: 0;
   margin-right: 0;
@@ -824,11 +834,15 @@ figure.m-figure img, figure.m-figure svg {
   border-top-right-radius: 0.2rem;
   max-width: 100%;
 }
-figure.m-figure.m-flat img, figure.m-figure.m-flat svg {
+figure.m-figure.m-flat img,
+figure.m-figure.m-flat svg,
+figure.m-figure.m-flat video {
   border-bottom-left-radius: 0.2rem;
   border-bottom-right-radius: 0.2rem;
 }
-figure.m-figure a img, figure.m-figure a svg {
+figure.m-figure a img,
+figure.m-figure a svg,
+figure.m-figure a video {
   margin-left: -1rem;
   margin-right: -1rem;
 }
@@ -838,10 +852,12 @@ figure.m-figure.m-fullwidth, figure.m-figure.m-fullwidth > * {
 figure.m-figure.m-fullwidth > *:first-child {
   display: inline;
 }
-figure.m-figure.m-fullwidth img, figure.m-figure.m-fullwidth svg {
+figure.m-figure.m-fullwidth img,
+figure.m-figure.m-fullwidth svg,
+figure.m-figure.m-fullwidth video {
   width: 100%;
 }
-figure.m-figure.m-fullwidth:after {
+figure.m-figure.m-fullwidth::after {
   content: ' ';
   display: block;
   margin-top: 1rem;
@@ -854,7 +870,7 @@ figure.m-figure.m-fullwidth:after {
   position: relative;
   padding: 1rem;
 }
-.m-code-figure:before, .m-console-figure:before {
+.m-code-figure::before, .m-console-figure::before {
   position: absolute;
   content: ' ';
   top: 0;
@@ -866,13 +882,13 @@ figure.m-figure.m-fullwidth:after {
   border-width: 0.125rem;
   border-radius: 0.2rem;
 }
-.m-code-figure:before {
+.m-code-figure::before {
   border-color: #282e36;
 }
-.m-console-figure:before {
-  border-color: #161616;
+.m-console-figure::before {
+  border-color: #1a1c1d;
 }
-.m-code-figure.m-flat:before, .m-console-figure.m-flat:before {
+.m-code-figure.m-flat::before, .m-console-figure.m-flat::before {
   border-color: transparent;
 }
 .m-code-figure > pre:first-child, .m-console-figure > pre:first-child {
@@ -893,6 +909,17 @@ figure.m-figure figcaption, .m-code-figure figcaption, .m-console-figure figcapt
   margin-bottom: 0.5rem;
   font-weight: 600;
   font-size: 1.17rem;
+}
+figure.m-figure figcaption a, .m-code-figure figcaption a, .m-console-figure figcaption a {
+  text-decoration: none;
+}
+figure.m-figure figcaption .m-figure-description {
+  margin-top: 0.5rem;
+  font-weight: normal;
+  font-size: 1rem;
+}
+figure.m-figure figcaption .m-figure-description a {
+  text-decoration: underline;
 }
 .m-imagegrid > div {
   background-color: #2f363f;
@@ -1137,18 +1164,18 @@ pre.m-code span.hll {
   margin-right: -1.0rem;
   padding-left: 1.0rem;
 }
-.m-code.m-inverted {
-  color: rgba(230, 230, 230, 0.33);
-}
-.m-code.m-inverted > span {
+.m-code.m-inverted > span, .m-console.m-inverted > span {
   opacity: 0.3333;
 }
-.m-code.m-inverted > span.hll {
-  color: #dcdcdc;
+.m-code.m-inverted > span.hll, .m-console.m-inverted > span.hll {
   opacity: 1;
   background-color: transparent;
   border-color: transparent;
 }
+.m-code.m-inverted { color: rgba(230, 230, 230, 0.33); }
+.m-console.m-inverted { color: rgba(230, 230, 230, 0.33); }
+.m-code.m-inverted > span.hll { color: #e6e6e6; }
+.m-cosole.m-inverted > span.hll { color: #e6e6e6; }
 .m-code-color {
   display: inline-block;
   width: 0.75rem;
@@ -1193,7 +1220,8 @@ div.m-plot svg .m-error {
   stroke-width: 1.5;
 }
 div.m-plot svg .m-label.m-dim { fill: #747474; }
-.m-graph g.m-edge path, .m-graph g.m-node.m-flat ellipse,
+.m-graph g.m-edge path, .m-graph g.m-cluster polygon,
+.m-graph g.m-node.m-flat ellipse,
 .m-graph g.m-node.m-flat polygon {
   fill: none;
 }
@@ -1257,7 +1285,7 @@ figure.m-figure:not(.m-flat) > svg.m-graph:first-child {
   color: #747474;
 }
 .m-block.m-flat { border-color: transparent; }
-.m-block.m-flat h3, .m-block.m-flat h4, .m-block.m-flat h5. .m-block.m-flat h6 {
+.m-block.m-flat h3, .m-block.m-flat h4, .m-block.m-flat h5, .m-block.m-flat h6 {
   color: #dcdcdc;
 }
 .m-block.m-default h3 a:hover, .m-block.m-default h3 a:focus, .m-block.m-default h3 a:active,
@@ -1481,19 +1509,24 @@ table.m-table tr.m-dim td a:active, table.m-table td.m-dim a:active,
 table.m-table tr.m-dim th a:active, table.m-table th.m-dim a:active {
   color: #747474;
 }
-figure.m-figure.m-default:before { border-color: #34424d; }
+figure.m-figure.m-default::before { border-color: #34424d; }
 figure.m-figure.m-default figcaption { color: #dcdcdc; }
-figure.m-figure.m-primary:before { border-color: #a5c2db; }
+figure.m-figure.m-primary::before { border-color: #a5c2db; }
 figure.m-figure.m-primary figcaption { color: #a5c9ea; }
-figure.m-figure.m-success:before { border-color: #2a703f; }
+figure.m-figure.m-primary figcaption .m-figure-description { color: #dcdcdc; }
+figure.m-figure.m-success::before { border-color: #2a703f; }
 figure.m-figure.m-success figcaption { color: #3bd267; }
-figure.m-figure.m-warning:before { border-color: #6d702a; }
+figure.m-figure.m-success figcaption .m-figure-description { color: #dcdcdc; }
+figure.m-figure.m-warning::before { border-color: #6d702a; }
 figure.m-figure.m-warning figcaption { color: #c7cf2f; }
-figure.m-figure.m-danger:before { border-color: #702b2a; }
+figure.m-figure.m-warning figcaption .m-figure-description { color: #dcdcdc; }
+figure.m-figure.m-danger::before { border-color: #702b2a; }
 figure.m-figure.m-danger figcaption { color: #cd3431; }
-figure.m-figure.m-info:before { border-color: #2a4f70; }
+figure.m-figure.m-danger figcaption .m-figure-description { color: #dcdcdc; }
+figure.m-figure.m-info::before { border-color: #2a4f70; }
 figure.m-figure.m-info figcaption { color: #2f83cc; }
-figure.m-figure.m-dim:before { border-color: #2d3236; }
+figure.m-figure.m-info figcaption .m-figure-description { color: #dcdcdc; }
+figure.m-figure.m-dim::before { border-color: #2d3236; }
 figure.m-figure.m-dim { color: #747474; }
 figure.m-figure.m-dim a { color: #acacac; }
 figure.m-figure.m-dim a:hover, figure.m-figure.m-dim a:focus, figure.m-figure.m-dim a:active {
@@ -1507,11 +1540,13 @@ div.m-plot svg .m-bar.m-default,
 .m-graph g.m-node:not(.m-flat) polygon,
 .m-graph g.m-edge text,
 .m-graph g.m-node.m-flat text,
+.m-graph g.m-cluster text,
 .m-graph.m-default g.m-edge polygon,
 .m-graph.m-default g.m-node:not(.m-flat) ellipse,
 .m-graph.m-default g.m-node:not(.m-flat) polygon,
 .m-graph.m-default g.m-edge text,
-.m-graph.m-default g.m-node.m-flat text {
+.m-graph.m-default g.m-node.m-flat text,
+.m-graph.m-default g.m-cluster text {
   fill: #dcdcdc;
 }
 .m-graph g.m-edge polygon,
@@ -1519,11 +1554,13 @@ div.m-plot svg .m-bar.m-default,
 .m-graph g.m-node ellipse,
 .m-graph g.m-node polygon,
 .m-graph g.m-node polyline,
+.m-graph g.m-cluster polygon,
 .m-graph.m-default g.m-edge polygon,
 .m-graph.m-default g.m-edge path,
 .m-graph.m-default g.m-node ellipse,
 .m-graph.m-default g.m-node polygon,
-.m-graph.m-default g.m-node polyline {
+.m-graph.m-default g.m-node polyline,
+.m-graph.m-default g.m-cluster polygon {
   stroke: #dcdcdc;
 }
 .m-math.m-primary, .m-math g.m-primary, .m-math rect.m-primary,
@@ -1532,14 +1569,16 @@ div.m-plot svg .m-bar.m-primary,
 .m-graph.m-primary g.m-node:not(.m-flat) ellipse,
 .m-graph.m-primary g.m-node:not(.m-flat) polygon,
 .m-graph.m-primary g.m-edge text,
-.m-graph.m-primary g.m-node.m-flat text {
+.m-graph.m-primary g.m-node.m-flat text,
+.m-graph.m-primary g.m-cluster text {
   fill: #a5c9ea;
 }
 .m-graph.m-primary g.m-edge polygon,
 .m-graph.m-primary g.m-edge path,
 .m-graph.m-primary g.m-node ellipse,
 .m-graph.m-primary g.m-node polygon,
-.m-graph.m-primary g.m-node polyline {
+.m-graph.m-primary g.m-node polyline,
+.m-graph.m-primary g.m-cluster polygon {
   stroke: #a5c9ea;
 }
 .m-math.m-success, .m-math g.m-success, .m-math rect.m-success,
@@ -1548,14 +1587,16 @@ div.m-plot svg .m-bar.m-success,
 .m-graph.m-success g.m-node:not(.m-flat) ellipse,
 .m-graph.m-success g.m-node:not(.m-flat) polygon,
 .m-graph.m-success g.m-edge text,
-.m-graph.m-success g.m-node.m-flat text {
+.m-graph.m-success g.m-node.m-flat text,
+.m-graph.m-success g.m-cluster text {
   fill: #3bd267;
 }
 .m-graph.m-success g.m-edge polygon,
 .m-graph.m-success g.m-edge path,
 .m-graph.m-success g.m-node ellipse,
 .m-graph.m-success g.m-node polygon,
-.m-graph.m-success g.m-node polyline {
+.m-graph.m-success g.m-node polyline,
+.m-graph.m-success g.m-cluster polygon {
   stroke: #3bd267;
 }
 .m-math.m-warning, .m-math g.m-warning, .m-math rect.m-warning,
@@ -1564,14 +1605,16 @@ div.m-plot svg .m-bar.m-warning,
 .m-graph.m-warning g.m-node:not(.m-flat) ellipse,
 .m-graph.m-warning g.m-node:not(.m-flat) polygon,
 .m-graph.m-warning g.m-edge text,
-.m-graph.m-warning g.m-node.m-flat text {
+.m-graph.m-warning g.m-node.m-flat text,
+.m-graph.m-warning g.m-cluster text {
   fill: #c7cf2f;
 }
 .m-graph.m-warning g.m-edge polygon,
 .m-graph.m-warning g.m-edge path,
 .m-graph.m-warning g.m-node ellipse,
 .m-graph.m-warning g.m-node polygon,
-.m-graph.m-warning g.m-node polyline {
+.m-graph.m-warning g.m-node polyline,
+.m-graph.m-warning g.m-cluster polygon {
   stroke: #c7cf2f;
 }
 .m-math.m-danger, .m-math g.m-danger, .m-math rect.m-danger,
@@ -1580,14 +1623,16 @@ div.m-plot svg .m-bar.m-danger,
 .m-graph.m-danger g.m-node:not(.m-flat) ellipse,
 .m-graph.m-danger g.m-node:not(.m-flat) polygon,
 .m-graph.m-danger g.m-edge text,
-.m-graph.m-danger g.m-node.m-flat text {
+.m-graph.m-danger g.m-node.m-flat text,
+.m-graph.m-danger g.m-cluster text {
   fill: #cd3431;
 }
 .m-graph.m-danger g.m-edge polygon,
 .m-graph.m-danger g.m-edge path,
 .m-graph.m-danger g.m-node ellipse,
 .m-graph.m-danger g.m-node polygon,
-.m-graph.m-danger g.m-node polyline {
+.m-graph.m-danger g.m-node polyline,
+.m-graph.m-danger g.m-cluster polygon {
   stroke: #cd3431;
 }
 .m-math.m-info, .m-math g.m-info, .m-math rect.m-info,
@@ -1596,14 +1641,16 @@ div.m-plot svg .m-bar.m-info,
 .m-graph.m-info g.m-node:not(.m-flat) ellipse,
 .m-graph.m-info g.m-node:not(.m-flat) polygon,
 .m-graph.m-info g.m-edge text,
-.m-graph.m-info g.m-node.m-flat text {
+.m-graph.m-info g.m-node.m-flat text,
+.m-graph.m-info g.m-cluster text {
   fill: #2f83cc;
 }
 .m-graph.m-info g.m-edge polygon,
 .m-graph.m-info g.m-edge path,
 .m-graph.m-info g.m-node ellipse,
 .m-graph.m-info g.m-node polygon,
-.m-graph.m-info g.m-node polyline {
+.m-graph.m-info g.m-node polyline,
+.m-graph.m-info g.m-cluster polygon {
   stroke: #2f83cc;
 }
 .m-math.m-dim, .m-math g.m-dim, .m-math rect.m-dim,
@@ -1612,112 +1659,128 @@ div.m-plot svg .m-bar.m-dim,
 .m-graph.m-dim g.m-node:not(.m-flat) ellipse,
 .m-graph.m-dim g.m-node:not(.m-flat) polygon,
 .m-graph.m-dim g.m-edge text,
-.m-graph.m-dim g.m-node.m-flat text {
+.m-graph.m-dim g.m-node.m-flat text,
+.m-graph.m-dim g.m-cluster text {
   fill: #747474;
 }
 .m-graph.m-dim g.m-edge polygon,
 .m-graph.m-dim g.m-edge path,
 .m-graph.m-dim g.m-node ellipse,
 .m-graph.m-dim g.m-node polygon,
-.m-graph.m-dim g.m-node polyline {
+.m-graph.m-dim g.m-node polyline,
+.m-graph.m-dim g.m-cluster polygon {
   stroke: #747474;
 }
 .m-graph g.m-edge.m-default polygon,
 .m-graph g.m-node.m-default:not(.m-flat) ellipse,
 .m-graph g.m-node.m-default:not(.m-flat) polygon,
 .m-graph g.m-edge.m-default text,
-.m-graph g.m-node.m-default.m-flat text {
+.m-graph g.m-node.m-default.m-flat text,
+.m-graph g.m-cluster.m-default text {
   fill: #dcdcdc;
 }
 .m-graph g.m-edge.m-default polygon,
 .m-graph g.m-edge.m-default path,
 .m-graph g.m-node.m-default ellipse,
 .m-graph g.m-node.m-default polygon,
-.m-graph g.m-node.m-default polyline {
+.m-graph g.m-node.m-default polyline,
+.m-graph g.m-cluster.m-default polygon {
   stroke: #dcdcdc;
 }
 .m-graph g.m-edge.m-primary polygon,
 .m-graph g.m-node.m-primary:not(.m-flat) ellipse,
 .m-graph g.m-node.m-primary:not(.m-flat) polygon,
 .m-graph g.m-edge.m-primary text,
-.m-graph g.m-node.m-primary.m-flat text {
+.m-graph g.m-node.m-primary.m-flat text,
+.m-graph g.m-cluster.m-primary text {
   fill: #a5c9ea;
 }
 .m-graph g.m-edge.m-primary polygon,
 .m-graph g.m-edge.m-primary path,
 .m-graph g.m-node.m-primary ellipse,
 .m-graph g.m-node.m-primary polygon,
-.m-graph g.m-node.m-primary polyline {
+.m-graph g.m-node.m-primary polyline,
+.m-graph g.m-cluster.m-primary polygon {
   stroke: #a5c9ea;
 }
 .m-graph g.m-edge.m-success polygon,
 .m-graph g.m-node.m-success:not(.m-flat) ellipse,
 .m-graph g.m-node.m-success:not(.m-flat) polygon,
 .m-graph g.m-edge.m-success text,
-.m-graph g.m-node.m-success.m-flat text {
+.m-graph g.m-node.m-success.m-flat text,
+.m-graph g.m-cluster.m-success text {
   fill: #3bd267;
 }
 .m-graph g.m-edge.m-success polygon,
 .m-graph g.m-edge.m-success path,
 .m-graph g.m-node.m-success ellipse,
 .m-graph g.m-node.m-success polygon,
-.m-graph g.m-node.m-success polyline {
+.m-graph g.m-node.m-success polyline,
+.m-graph g.m-cluster.m-success polygon {
   stroke: #3bd267;
 }
 .m-graph g.m-edge.m-warning polygon,
 .m-graph g.m-node.m-warning:not(.m-flat) ellipse,
 .m-graph g.m-node.m-warning:not(.m-flat) polygon,
 .m-graph g.m-edge.m-warning text,
-.m-graph g.m-node.m-warning.m-flat text {
+.m-graph g.m-node.m-warning.m-flat text,
+.m-graph g.m-cluster.m-warning text {
   fill: #c7cf2f;
 }
 .m-graph g.m-edge.m-warning polygon,
 .m-graph g.m-edge.m-warning path,
 .m-graph g.m-node.m-warning ellipse,
 .m-graph g.m-node.m-warning polygon,
-.m-graph g.m-node.m-warning polyline {
+.m-graph g.m-node.m-warning polyline,
+.m-graph g.m-cluster.m-warning polygon {
   stroke: #c7cf2f;
 }
 .m-graph g.m-edge.m-danger polygon,
 .m-graph g.m-node.m-danger:not(.m-flat) ellipse,
 .m-graph g.m-node.m-danger:not(.m-flat) polygon,
 .m-graph g.m-edge.m-danger text,
-.m-graph g.m-node.m-danger.m-flat text {
+.m-graph g.m-node.m-danger.m-flat text,
+.m-graph g.m-cluster.m-danger text {
   fill: #cd3431;
 }
 .m-graph g.m-edge.m-danger polygon,
 .m-graph g.m-edge.m-danger path,
 .m-graph g.m-node.m-danger ellipse,
 .m-graph g.m-node.m-danger polygon,
-.m-graph g.m-node.m-danger polyline {
+.m-graph g.m-node.m-danger polyline,
+.m-graph g.m-cluster.m-danger polygon {
   stroke: #cd3431;
 }
 .m-graph g.m-edge.m-info polygon,
 .m-graph g.m-node.m-info:not(.m-flat) ellipse,
 .m-graph g.m-node.m-info:not(.m-flat) polygon,
 .m-graph g.m-edge.m-info text,
-.m-graph g.m-node.m-info.m-flat text {
+.m-graph g.m-node.m-info.m-flat text,
+.m-graph g.m-cluster.m-info text {
   fill: #2f83cc;
 }
 .m-graph g.m-edge.m-info polygon,
 .m-graph g.m-edge.m-info path,
 .m-graph g.m-node.m-info ellipse,
 .m-graph g.m-node.m-info polygon,
-.m-graph g.m-node.m-info polyline {
+.m-graph g.m-node.m-info polyline,
+.m-graph g.m-cluster.m-info polygon {
   stroke: #2f83cc;
 }
 .m-graph g.m-edge.m-dim polygon,
 .m-graph g.m-node.m-dim:not(.m-flat) ellipse,
 .m-graph g.m-node.m-dim:not(.m-flat) polygon,
 .m-graph g.m-edge.m-dim text,
-.m-graph g.m-node.m-dim.m-flat text {
+.m-graph g.m-node.m-dim.m-flat text,
+.m-graph g.m-cluster.m-dim text {
   fill: #747474;
 }
 .m-graph g.m-edge.m-dim polygon,
 .m-graph g.m-edge.m-dim path,
 .m-graph g.m-node.m-dim ellipse,
 .m-graph g.m-node.m-dim polygon,
-.m-graph g.m-node.m-dim polyline {
+.m-graph g.m-node.m-dim polyline,
+.m-graph g.m-cluster.m-dim polygon {
   stroke: #747474;
 }
 p, ul, ol, dl, blockquote, pre, .m-code-figure, .m-console-figure, hr, .m-note,
@@ -2026,9 +2089,9 @@ html:not(.m-presenter) .m-container { width: 100%; }
 .m-code .dl { color: #e07f7c }
 .m-code .sd { color: #e07f7c }
 .m-code .s2 { color: #e07f7c }
-.m-code .se { color: #e07f7c }
+.m-code .se { color: #e07cdc }
 .m-code .sh { color: #e07f7c }
-.m-code .si { color: #e07f7c }
+.m-code .si { color: #a5c9ea }
 .m-code .sx { color: #e07f7c }
 .m-code .sr { color: #e07f7c }
 .m-code .s1 { color: #e07f7c }
@@ -2042,24 +2105,41 @@ html:not(.m-presenter) .m-container { width: 100%; }
 .m-code .il { color: #c7cf2f }
 
 .m-console .hll { background-color: #ffffcc }
-.m-console .g-AnsiBlack { color: #000000 }
-.m-console .g-AnsiBlue { color: #3f3fd1 }
-.m-console .g-AnsiBrightBlack { color: #686868; font-weight: bold }
-.m-console .g-AnsiBrightBlue { color: #5454ff; font-weight: bold }
-.m-console .g-AnsiBrightCyan { color: #54ffff; font-weight: bold }
+.m-console .g-AnsiBackgroundBlack { background-color: #232627 }
+.m-console .g-AnsiBackgroundBlue { background-color: #1d99f3 }
+.m-console .g-AnsiBackgroundBrightBlack { background-color: #7f8c8d }
+.m-console .g-AnsiBackgroundBrightBlue { background-color: #3daee9 }
+.m-console .g-AnsiBackgroundBrightCyan { background-color: #16a085 }
+.m-console .g-AnsiBackgroundBrightGreen { background-color: #1cdc9a }
+.m-console .g-AnsiBackgroundBrightMagenta { background-color: #8e44ad }
+.m-console .g-AnsiBackgroundBrightRed { background-color: #c0392b }
+.m-console .g-AnsiBackgroundBrightWhite { background-color: #ffffff }
+.m-console .g-AnsiBackgroundBrightYellow { background-color: #fdbc4b }
+.m-console .g-AnsiBackgroundCyan { background-color: #1abc9c }
+.m-console .g-AnsiBackgroundGreen { background-color: #11d116 }
+.m-console .g-AnsiBackgroundMagenta { background-color: #9b59b6 }
+.m-console .g-AnsiBackgroundRed { background-color: #ed1515 }
+.m-console .g-AnsiBackgroundWhite { background-color: #fcfcfc }
+.m-console .g-AnsiBackgroundYellow { background-color: #f67400 }
+.m-console .g-AnsiBlack { color: #232627 }
+.m-console .g-AnsiBlue { color: #1d99f3 }
+.m-console .g-AnsiBrightBlack { color: #7f8c8d; font-weight: bold }
+.m-console .g-AnsiBrightBlue { color: #3daee9; font-weight: bold }
+.m-console .g-AnsiBrightCyan { color: #16a085; font-weight: bold }
 .m-console .g-AnsiBrightDefault { color: #ffffff; font-weight: bold }
-.m-console .g-AnsiBrightGreen { color: #54ff54; font-weight: bold }
-.m-console .g-AnsiBrightMagenta { color: #ff54ff; font-weight: bold }
-.m-console .g-AnsiBrightRed { color: #ff5454; font-weight: bold }
+.m-console .g-AnsiBrightGreen { color: #1cdc9a; font-weight: bold }
+.m-console .g-AnsiBrightInvertedDefault { color: #1a1c1d; font-weight: bold }
+.m-console .g-AnsiBrightMagenta { color: #8e44ad; font-weight: bold }
+.m-console .g-AnsiBrightRed { color: #c0392b; font-weight: bold }
 .m-console .g-AnsiBrightWhite { color: #ffffff; font-weight: bold }
-.m-console .g-AnsiBrightYellow { color: #ffff54; font-weight: bold }
-.m-console .g-AnsiCyan { color: #18b2b2 }
-.m-console .g-AnsiDefault { color: #b2b2b2 }
-.m-console .g-AnsiGreen { color: #18b218 }
-.m-console .g-AnsiMagenta { color: #b218b2 }
-.m-console .g-AnsiRed { color: #b21818 }
-.m-console .g-AnsiWhite { color: #b2b2b2 }
-.m-console .g-AnsiYellow { color: #b26818 }
-.m-console .go { color: #b2b2b2 }
-.m-console .gp { color: #54ffff; font-weight: bold }
-.m-console .w { color: #b2b2b2 }
+.m-console .g-AnsiBrightYellow { color: #fdbc4b; font-weight: bold }
+.m-console .g-AnsiCyan { color: #1abc9c }
+.m-console .g-AnsiGreen { color: #11d116 }
+.m-console .g-AnsiInvertedDefault { color: #1a1c1d }
+.m-console .g-AnsiMagenta { color: #9b59b6 }
+.m-console .g-AnsiRed { color: #ed1515 }
+.m-console .g-AnsiWhite { color: #fcfcfc }
+.m-console .g-AnsiYellow { color: #f67400 }
+.m-console .go { color: #fcfcfc }
+.m-console .gp { color: #16a085; font-weight: bold }
+.m-console .w { color: #fcfcfc }

--- a/css/m-dark-presentation.compiled.css
+++ b/css/m-dark-presentation.compiled.css
@@ -1,0 +1,2065 @@
+/* Generated using `./postprocess.py m-dark-presentation.css`. Do not edit. */
+
+/*
+    This file is part of m.css.
+
+    Copyright © 2017, 2018, 2019 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+*, ::before, ::after { box-sizing: border-box; }
+body { margin: 0; }
+.m-container {
+  width: 100%;
+  margin: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.m-row {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+.m-row:after {
+  content: ' ';
+  clear: both;
+  display: table;
+}
+.m-row > [class*='m-col-'] {
+  position: relative;
+  padding: 1rem;
+}
+[class*='m-clearfix-']::after {
+  display: block;
+  content: ' ';
+  clear: both;
+}
+[class*='m-show-'] {
+  display: none;
+}
+.m-container-inflate, :not(.m-row) > [class*='m-col-'] {
+  margin-bottom: 1rem;
+}
+.m-container-inflate:last-child, :not(.m-row) > [class*='m-col-']:last-child {
+  margin-bottom: 0;
+}
+.m-container.m-nopad, [class*='m-col-'].m-nopad,
+.m-container.m-nopadx, [class*='m-col-'].m-nopadx,
+.m-container.m-nopadl, [class*='m-col-'].m-nopadl {
+  padding-left: 0;
+}
+.m-container.m-nopad, [class*='m-col-'].m-nopad,
+.m-container.m-nopadx, [class*='m-col-'].m-nopadx,
+.m-container.m-nopadr, [class*='m-col-'].m-nopadr {
+  padding-right: 0;
+}
+[class*='m-col-'].m-nopad, [class*='m-col-'].m-nopady, [class*='m-col-'].m-nopadt {
+  padding-top: 0;
+}
+[class*='m-col-'].m-nopad, [class*='m-col-'].m-nopady, [class*='m-col-'].m-nopadb,
+.m-container-inflate.m-nopadb {
+  padding-bottom: 0;
+}
+[class*='m-col-t-'] { float: left; }
+.m-left-t {
+  padding-right: 1rem;
+  float: left;
+}
+.m-right-t, [class*='m-col-t-'].m-right-t {
+  padding-left: 1rem;
+  float: right;
+}
+.m-center-t, [class*='m-col-t-'].m-center-t {
+  float: none;
+}
+.m-center-t, [class*='m-col-t-'].m-center-t {
+  margin-left: auto;
+  margin-right: auto;
+  float: none;
+}
+.m-col-t-1  { width: calc(1  * 100% / 12); }
+.m-col-t-2  { width: calc(2  * 100% / 12); }
+.m-col-t-3  { width: calc(3  * 100% / 12); }
+.m-col-t-4  { width: calc(4  * 100% / 12); }
+.m-col-t-5  { width: calc(5  * 100% / 12); }
+.m-col-t-6  { width: calc(6  * 100% / 12); }
+.m-col-t-7  { width: calc(7  * 100% / 12); }
+.m-col-t-8  { width: calc(8  * 100% / 12); }
+.m-col-t-9  { width: calc(9  * 100% / 12); }
+.m-col-t-10 { width: calc(10 * 100% / 12); }
+.m-col-t-11 { width: calc(11 * 100% / 12); }
+.m-col-t-12 { width: calc(12 * 100% / 12); }
+.m-push-t-1  { left: calc(1  * 100% / 12); }
+.m-push-t-2  { left: calc(2  * 100% / 12); }
+.m-push-t-3  { left: calc(3  * 100% / 12); }
+.m-push-t-4  { left: calc(4  * 100% / 12); }
+.m-push-t-5  { left: calc(5  * 100% / 12); }
+.m-push-t-6  { left: calc(6  * 100% / 12); }
+.m-push-t-7  { left: calc(7  * 100% / 12); }
+.m-push-t-8  { left: calc(8  * 100% / 12); }
+.m-push-t-9  { left: calc(9  * 100% / 12); }
+.m-push-t-10 { left: calc(10 * 100% / 12); }
+.m-push-t-11 { left: calc(11 * 100% / 12); }
+.m-pull-t-1  { right: calc(1  * 100% / 12); }
+.m-pull-t-2  { right: calc(2  * 100% / 12); }
+.m-pull-t-3  { right: calc(3  * 100% / 12); }
+.m-pull-t-4  { right: calc(4  * 100% / 12); }
+.m-pull-t-5  { right: calc(5  * 100% / 12); }
+.m-pull-t-6  { right: calc(6  * 100% / 12); }
+.m-pull-t-7  { right: calc(7  * 100% / 12); }
+.m-pull-t-8  { right: calc(8  * 100% / 12); }
+.m-pull-t-9  { right: calc(9  * 100% / 12); }
+.m-pull-t-10 { right: calc(10 * 100% / 12); }
+.m-pull-t-11 { right: calc(11 * 100% / 12); }
+@media screen and (min-width: 576px) {
+  .m-container { width: 560px; }
+  .m-container-inflatable .m-col-s-10 .m-container-inflate:not([class*='m-left-']):not([class*='m-right-']) {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+  .m-container-inflatable .m-col-s-10 .m-container-inflate.m-left-s {
+    margin-left: -10%;
+  }
+  .m-container-inflatable .m-col-s-10 .m-container-inflate.m-right-s {
+    margin-right: -10%;
+  }
+  [class*='m-col-s-'] { float: left; }
+  .m-left-s {
+    padding-right: 1rem;
+    float: left;
+  }
+  .m-right-s, [class*='m-col-s-'].m-right-s {
+    padding-left: 1rem;
+    float: right;
+  }
+  .m-center-s, [class*='m-col-s-'].m-center-s {
+    margin-left: auto;
+    margin-right: auto;
+    float: none;
+  }
+  .m-col-s-1  { width: calc(1  * 100% / 12); }
+  .m-col-s-2  { width: calc(2  * 100% / 12); }
+  .m-col-s-3  { width: calc(3  * 100% / 12); }
+  .m-col-s-4  { width: calc(4  * 100% / 12); }
+  .m-col-s-5  { width: calc(5  * 100% / 12); }
+  .m-col-s-6  { width: calc(6  * 100% / 12); }
+  .m-col-s-7  { width: calc(7  * 100% / 12); }
+  .m-col-s-8  { width: calc(8  * 100% / 12); }
+  .m-col-s-9  { width: calc(9  * 100% / 12); }
+  .m-col-s-10 { width: calc(10 * 100% / 12); }
+  .m-col-s-11 { width: calc(11 * 100% / 12); }
+  .m-col-s-12 { width: calc(12 * 100% / 12); }
+  .m-push-s-0  { left: calc(0  * 100% / 12); }
+  .m-push-s-1  { left: calc(1  * 100% / 12); }
+  .m-push-s-2  { left: calc(2  * 100% / 12); }
+  .m-push-s-3  { left: calc(3  * 100% / 12); }
+  .m-push-s-4  { left: calc(4  * 100% / 12); }
+  .m-push-s-5  { left: calc(5  * 100% / 12); }
+  .m-push-s-6  { left: calc(6  * 100% / 12); }
+  .m-push-s-7  { left: calc(7  * 100% / 12); }
+  .m-push-s-8  { left: calc(8  * 100% / 12); }
+  .m-push-s-9  { left: calc(9  * 100% / 12); }
+  .m-push-s-10 { left: calc(10 * 100% / 12); }
+  .m-push-s-11 { left: calc(11 * 100% / 12); }
+  .m-pull-s-0  { right: calc(0  * 100% / 12); }
+  .m-pull-s-1  { right: calc(1  * 100% / 12); }
+  .m-pull-s-2  { right: calc(2  * 100% / 12); }
+  .m-pull-s-3  { right: calc(3  * 100% / 12); }
+  .m-pull-s-4  { right: calc(4  * 100% / 12); }
+  .m-pull-s-5  { right: calc(5  * 100% / 12); }
+  .m-pull-s-6  { right: calc(6  * 100% / 12); }
+  .m-pull-s-7  { right: calc(7  * 100% / 12); }
+  .m-pull-s-8  { right: calc(8  * 100% / 12); }
+  .m-pull-s-9  { right: calc(9  * 100% / 12); }
+  .m-pull-s-10 { right: calc(10 * 100% / 12); }
+  .m-pull-s-11 { right: calc(11 * 100% / 12); }
+  .m-clearfix-t::after { display: none; }
+  .m-hide-s { display: none; }
+  .m-show-s { display: block; }
+  .m-col-s-none {
+    width: auto;
+    float: none;
+  }
+}
+@media screen and (min-width: 768px) {
+  .m-container { width: 750px; }
+  .m-container-inflatable .m-col-m-10 .m-container-inflate:not([class*='m-left-']):not([class*='m-right-']) {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+  .m-container-inflatable .m-col-m-10 .m-container-inflate.m-left-m {
+    margin-left: -10%;
+  }
+  .m-container-inflatable .m-col-m-10 .m-container-inflate.m-right-m {
+    margin-right: -10%;
+  }
+  [class*='m-col-m-'] { float: left; }
+  .m-left-m {
+    padding-right: 1rem;
+    float: left;
+  }
+  .m-right-m, [class*='m-col-m-'].m-right-m {
+    padding-left: 1rem;
+    float: right;
+  }
+  .m-center-m, [class*='m-col-m-'].m-center-m {
+    margin-left: auto;
+    margin-right: auto;
+    float: none;
+  }
+  .m-col-m-1  { width: calc(1  * 100% / 12); }
+  .m-col-m-2  { width: calc(2  * 100% / 12); }
+  .m-col-m-3  { width: calc(3  * 100% / 12); }
+  .m-col-m-4  { width: calc(4  * 100% / 12); }
+  .m-col-m-5  { width: calc(5  * 100% / 12); }
+  .m-col-m-6  { width: calc(6  * 100% / 12); }
+  .m-col-m-7  { width: calc(7  * 100% / 12); }
+  .m-col-m-8  { width: calc(8  * 100% / 12); }
+  .m-col-m-9  { width: calc(9  * 100% / 12); }
+  .m-col-m-10 { width: calc(10 * 100% / 12); }
+  .m-col-m-11 { width: calc(11 * 100% / 12); }
+  .m-col-m-12 { width: calc(12 * 100% / 12); }
+  .m-push-m-0  { left: calc(0  * 100% / 12); }
+  .m-push-m-1  { left: calc(1  * 100% / 12); }
+  .m-push-m-2  { left: calc(2  * 100% / 12); }
+  .m-push-m-3  { left: calc(3  * 100% / 12); }
+  .m-push-m-4  { left: calc(4  * 100% / 12); }
+  .m-push-m-5  { left: calc(5  * 100% / 12); }
+  .m-push-m-6  { left: calc(6  * 100% / 12); }
+  .m-push-m-7  { left: calc(7  * 100% / 12); }
+  .m-push-m-8  { left: calc(8  * 100% / 12); }
+  .m-push-m-9  { left: calc(9  * 100% / 12); }
+  .m-push-m-10 { left: calc(10 * 100% / 12); }
+  .m-push-m-11 { left: calc(11 * 100% / 12); }
+  .m-pull-m-0  { right: calc(0  * 100% / 12); }
+  .m-pull-m-1  { right: calc(1  * 100% / 12); }
+  .m-pull-m-2  { right: calc(2  * 100% / 12); }
+  .m-pull-m-3  { right: calc(3  * 100% / 12); }
+  .m-pull-m-4  { right: calc(4  * 100% / 12); }
+  .m-pull-m-5  { right: calc(5  * 100% / 12); }
+  .m-pull-m-6  { right: calc(6  * 100% / 12); }
+  .m-pull-m-7  { right: calc(7  * 100% / 12); }
+  .m-pull-m-8  { right: calc(8  * 100% / 12); }
+  .m-pull-m-9  { right: calc(9  * 100% / 12); }
+  .m-pull-m-10 { right: calc(10 * 100% / 12); }
+  .m-pull-m-11 { right: calc(11 * 100% / 12); }
+  .m-clearfix-s::after { display: none; }
+  .m-hide-m { display: none; }
+  .m-show-m { display: block; }
+  .m-col-m-none {
+    width: auto;
+    float: none;
+  }
+}
+@media screen and (min-width: 992px) {
+  .m-container { width: 960px; }
+  .m-container-inflatable .m-col-l-10 .m-container-inflate:not([class*='m-left-']):not([class*='m-right-']) {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+  .m-container-inflatable .m-col-l-10 .m-container-inflate.m-left-l {
+    margin-left: -10%;
+  }
+  .m-container-inflatable .m-col-l-10 .m-container-inflate.m-right-l {
+    margin-right: -10%;
+  }
+  [class*='m-col-l-'] { float: left; }
+  .m-left-l {
+    padding-right: 1rem;
+    float: left;
+  }
+  .m-right-l, [class*='m-col-l-'].m-right-l {
+    padding-left: 1rem;
+    float: right;
+  }
+  .m-center-l, [class*='m-col-l-'].m-center-l {
+    margin-left: auto;
+    margin-right: auto;
+    float: none;
+  }
+  .m-col-l-1  { width: calc(1  * 100% / 12); }
+  .m-col-l-2  { width: calc(2  * 100% / 12); }
+  .m-col-l-3  { width: calc(3  * 100% / 12); }
+  .m-col-l-4  { width: calc(4  * 100% / 12); }
+  .m-col-l-5  { width: calc(5  * 100% / 12); }
+  .m-col-l-6  { width: calc(6  * 100% / 12); }
+  .m-col-l-7  { width: calc(7  * 100% / 12); }
+  .m-col-l-8  { width: calc(8  * 100% / 12); }
+  .m-col-l-9  { width: calc(9  * 100% / 12); }
+  .m-col-l-10 { width: calc(10 * 100% / 12); }
+  .m-col-l-11 { width: calc(11 * 100% / 12); }
+  .m-col-l-12 { width: calc(12 * 100% / 12); }
+  .m-push-l-0  { left: calc(0  * 100% / 12); }
+  .m-push-l-1  { left: calc(1  * 100% / 12); }
+  .m-push-l-2  { left: calc(2  * 100% / 12); }
+  .m-push-l-3  { left: calc(3  * 100% / 12); }
+  .m-push-l-4  { left: calc(4  * 100% / 12); }
+  .m-push-l-5  { left: calc(5  * 100% / 12); }
+  .m-push-l-6  { left: calc(6  * 100% / 12); }
+  .m-push-l-7  { left: calc(7  * 100% / 12); }
+  .m-push-l-8  { left: calc(8  * 100% / 12); }
+  .m-push-l-9  { left: calc(9  * 100% / 12); }
+  .m-push-l-10 { left: calc(10 * 100% / 12); }
+  .m-push-l-11 { left: calc(11 * 100% / 12); }
+  .m-pull-l-0  { right: calc(0  * 100% / 12); }
+  .m-pull-l-1  { right: calc(1  * 100% / 12); }
+  .m-pull-l-2  { right: calc(2  * 100% / 12); }
+  .m-pull-l-3  { right: calc(3  * 100% / 12); }
+  .m-pull-l-4  { right: calc(4  * 100% / 12); }
+  .m-pull-l-5  { right: calc(5  * 100% / 12); }
+  .m-pull-l-6  { right: calc(6  * 100% / 12); }
+  .m-pull-l-7  { right: calc(7  * 100% / 12); }
+  .m-pull-l-8  { right: calc(8  * 100% / 12); }
+  .m-pull-l-9  { right: calc(9  * 100% / 12); }
+  .m-pull-l-10 { right: calc(10 * 100% / 12); }
+  .m-pull-l-11 { right: calc(11 * 100% / 12); }
+  .m-clearfix-m::after { display: none; }
+  .m-hide-l { display: none; }
+  .m-show-l { display: block; }
+  .m-col-l-none {
+    width: auto;
+    float: none;
+  }
+}
+
+html {
+  font-size: 16px;
+  background-color: #2f363f;
+}
+body {
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: 1rem;
+  color: #dcdcdc;
+}
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0;
+  font-weight: 600;
+}
+h1 {
+  margin-bottom: 1rem;
+}
+h2, h3, h4, h5, h6 {
+  margin-bottom: 0.5rem;
+}
+p, ul, ol, dl {
+  margin-top: 0;
+}
+ul, ol {
+  padding-left: 2rem;
+}
+ul ol, ul ul, ol ol, ol ul {
+  margin-bottom: 0;
+}
+main p {
+  text-indent: 1.5rem;
+  text-align: justify;
+}
+main p.m-noindent, li > p, dd > p, table.m-table td > p {
+  text-indent: 0;
+  text-align: left;
+}
+blockquote {
+  margin-top: 0;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  padding: 1rem;
+  border-left-style: solid;
+  border-left-width: 0.25rem;
+}
+hr {
+  width: 75%;
+  border-width: 0.0625rem;
+  border-style: solid;
+}
+blockquote, hr {
+  border-color: #405363;
+}
+pre {
+  font-family: 'Source Code Pro', monospace, monospace, monospace;
+  font-size: 0.9em;
+  padding: 0.5rem 1rem;
+  color: #e6e6e6;
+  background-color: #282e36;
+  border-radius: 0.2rem;
+  overflow-x: auto;
+  margin-top: 0;
+}
+pre.m-console-wrap {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+pre.m-console {
+  background-color: #161616;
+}
+strong, .m-text.m-strong { font-weight: bold; }
+em, .m-text.m-em { font-style: italic; }
+s, .m-text.m-s { text-decoration: line-through; }
+sub, sup, .m-text.m-sub, .m-text.m-sup {
+  font-size: 0.75rem;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sup, .m-text.m-sup { top: -0.35rem; }
+sub, .m-text.m-sub { bottom: -0.2rem; }
+abbr {
+  cursor: help;
+  text-decoration: underline dotted;
+}
+a {
+  color: #5b9dd9;
+}
+a.m-flat {
+  text-decoration: none;
+}
+a:hover, a:focus, a:active {
+  color: #a5c9ea;
+}
+a img { border: 0; }
+svg a { cursor: pointer; }
+mark {
+  padding: 0.0625rem;
+  background-color: #c7cf2f;
+  color: #2f83cc;
+}
+code {
+  font-family: 'Source Code Pro', monospace, monospace, monospace;
+  font-size: 0.9em;
+  padding: 0.125rem;
+  color: #e6e6e6;
+  background-color: #282e36;
+}
+code.m-console {
+  background-color: #161616;
+}
+*:focus { outline-color: #5b9dd9; }
+div.m-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+}
+.m-fullwidth {
+  width: 100%;
+}
+.m-spacing-150 {
+  line-height: 1.5rem;
+}
+.m-text-center, .m-text-center.m-noindent, table.m-table th.m-text-center, .m-text-center p {
+  text-align: center;
+}
+.m-text-left, .m-text-left.m-noindent, table.m-table th.m-text-left, .m-text-right p {
+  text-align: left;
+}
+.m-text-right, .m-text-right.m-noindent, table.m-table th.m-text-right, .m-text-right p {
+  text-align: right;
+}
+.m-text-top, table.m-table th.m-text-top, table.m-table td.m-text-top {
+  vertical-align: top;
+}
+.m-text-middle, table.m-table th.m-text-middle, table.m-table td.m-text-middle {
+  vertical-align: middle;
+}
+.m-text-bottom, table.m-table th.m-text-bottom, table.m-table td.m-text-bottom {
+  vertical-align: bottom;
+}
+.m-text.m-tiny { font-size: 50.0%; }
+.m-text.m-small { font-size: 85.4%; }
+.m-text.m-big { font-size: 117%; }
+h1 .m-thin, h2 .m-thin, h3 .m-thin, h4 .m-thin, h5 .m-thin, h6 .m-thin {
+  font-weight: normal;
+}
+ul.m-unstyled, ol.m-unstyled {
+  list-style-type: none;
+  padding-left: 0;
+}
+ul[class*='m-block-'], ol[class*='m-block-'] {
+  padding-left: 0;
+}
+ul[class*='m-block-'] li, ol[class*='m-block-'] li {
+  display: inline;
+}
+ul[class*='m-block-bar-'] li:not(:last-child)::after, ol[class*='m-block-bar-'] li:not(:last-child)::after {
+  content: " | ";
+}
+ul[class*='m-block-dot-'] li:not(:last-child)::after, ol[class*='m-block-dot-'] li:not(:last-child)::after {
+  content: " • ";
+}
+@media screen and (min-width: 576px) {
+  ul.m-block-bar-s, ol.m-block-bar-s,
+  ul.m-block-dot-s, ol.m-block-dot-s { padding-left: 2rem; }
+  ul.m-block-bar-s li, ol.m-block-bar-s li,
+  ul.m-block-dot-s li, ol.m-block-dot-s li { display: list-item; }
+  ul.m-block-bar-s li:not(:last-child)::after, ol.m-block-bar-s li:not(:last-child)::after,
+  ul.m-block-dot-s li:not(:last-child)::after, ol.m-block-dot-s li:not(:last-child)::after { content: ""; }
+}
+@media screen and (min-width: 768px) {
+  ul.m-block-bar-m, ol.m-block-bar-m,
+  ul.m-block-dot-m, ol.m-block-dot-m { padding-left: 2rem; }
+  ul.m-block-bar-m li, ol.m-block-bar-m li,
+  ul.m-block-dot-m li, ol.m-block-dot-m li { display: list-item; }
+  ul.m-block-bar-m li:not(:last-child)::after, ol.m-block-bar-m li:not(:last-child)::after,
+  ul.m-block-dot-m li:not(:last-child)::after, ol.m-block-dot-m li:not(:last-child)::after { content: ""; }
+}
+@media screen and (min-width: 992px) {
+  ul.m-block-bar-l, ol.m-block-bar-l,
+  ul.m-block-dot-l, ol.m-block-dot-l { padding-left: 2rem; }
+  ul.m-block-bar-l li, ol.m-block-bar-l li,
+  ul.m-block-dot-l li, ol.m-block-dot-l li { display: list-item; }
+  ul.m-block-bar-l li:not(:last-child)::after, ol.m-block-bar-l li:not(:last-child)::after,
+  ul.m-block-dot-l li:not(:last-child)::after, ol.m-block-dot-l li:not(:last-child)::after { content: ""; }
+}
+p.m-poem {
+  text-indent: 0;
+  text-align: left;
+  margin-left: 1.5rem;
+}
+p.m-transition {
+  color: #405363;
+  text-indent: 0;
+  text-align: center;
+  font-size: 2rem;
+}
+dl.m-diary {
+  margin-bottom: 1.25rem;
+}
+dl.m-diary:last-child {
+  margin-bottom: 0.25rem;
+}
+dl.m-diary dt {
+  font-weight: bold;
+  width: 3.5rem;
+  float: left;
+  clear: both;
+  padding-top: 0.25rem;
+}
+dl.m-diary dd {
+  padding-top: 0.25rem;
+  padding-left: 3.5rem;
+}
+a.m-footnote, dl.m-footnote dd span.m-footnote {
+  top: -0.35rem;
+  font-size: 0.75rem;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+a.m-footnote, dl.m-footnote dd span.m-footnote a {
+  text-decoration: none;
+}
+a.m-footnote::before { content: '['; }
+a.m-footnote::after { content: ']'; }
+dl.m-footnote dt {
+  width: 1.5rem;
+  float: left;
+  clear: both;
+}
+dl.m-footnote dd {
+  margin-left: 1.5rem;
+}
+dl.m-footnote {
+  font-size: 85.4%;
+}
+dl.m-footnote dd span.m-footnote a {
+  font-weight: bold;
+  font-style: italic;
+}
+.m-note {
+  border-radius: 0.2rem;
+  padding: 1rem;
+}
+.m-frame {
+  background-color: #2f363f;
+  border-style: solid;
+  border-width: 0.125rem;
+  border-radius: 0.2rem;
+  border-color: #405363;
+  padding: 0.875rem;
+}
+.m-block {
+  border-style: solid;
+  border-width: 0.0625rem;
+  border-left-width: 0.25rem;
+  border-radius: 0.2rem;
+  border-color: #405363;
+  padding: 0.9375rem 0.9375rem 0.9375rem 0.75rem;
+}
+.m-block.m-badge::after {
+  content: ' ';
+  display: block;
+  clear: both;
+}
+.m-block.m-badge h3 {
+  margin-left: 5rem;
+}
+.m-block.m-badge p {
+  margin-left: 5rem;
+  text-indent: 0;
+}
+.m-block.m-badge img {
+  width: 4rem;
+  height: 4rem;
+  border-radius: 2rem;
+  float: left;
+}
+div.m-button {
+  text-align: center;
+}
+div.m-button a {
+  display: inline-block;
+  border-radius: 0.2rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  text-decoration: none;
+  font-size: 1.17rem;
+}
+div.m-button.m-fullwidth a {
+  display: block;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+div.m-button a .m-big:first-child {
+  font-size: 1.37rem;
+  font-weight: bold;
+}
+div.m-button a .m-small:last-child {
+  font-size: 0.854rem;
+}
+.m-label {
+  border-radius: 0.2rem;
+  font-size: 75%;
+  font-weight: normal;
+  padding: 0.125rem 0.25rem;
+  vertical-align: 7.5%;
+}
+.m-label.m-flat {
+  border-width: 0.0625rem;
+  border-style: solid;
+  border-color: #747474;
+  padding: 0.0625rem 0.1875rem;
+}
+table.m-table {
+  border-collapse: collapse;
+  margin-left: auto;
+  margin-right: auto;
+}
+table.m-table.m-big {
+  margin-top: 1.75rem;
+}
+div.m-scroll > table.m-table:last-child {
+  margin-bottom: 0.0625rem;
+}
+table.m-table:not(.m-flat) tbody tr:hover {
+  background-color: #405363;
+}
+table.m-table th, table.m-table td {
+  vertical-align: top;
+  border-style: solid;
+  border-top-width: 0.0625rem;
+  border-left-width: 0;
+  border-right-width: 0;
+  border-bottom-width: 0;
+  border-color: #405363;
+}
+table.m-table caption {
+  padding-bottom: 0.5rem;
+}
+table.m-table thead tr:first-child th, table.m-table thead tr:first-child td {
+  border-top-width: 0.125rem;
+}
+table.m-table thead th, table.m-table thead td {
+  border-bottom-width: 0.125rem;
+  vertical-align: bottom;
+}
+table.m-table tfoot th, table.m-table tfoot td {
+  border-top-width: 0.125rem;
+}
+table.m-table th, table.m-table td {
+  padding: 0.5rem;
+}
+table.m-table.m-big th, table.m-table.m-big td {
+  padding: 0.75rem 1rem;
+}
+table.m-table th {
+  text-align: left;
+}
+table.m-table th.m-thin {
+  font-weight: normal;
+}
+table.m-table td.m-default, table.m-table th.m-default,
+table.m-table td.m-primary, table.m-table th.m-primary,
+table.m-table td.m-success, table.m-table th.m-success,
+table.m-table td.m-warning, table.m-table th.m-warning,
+table.m-table td.m-danger, table.m-table th.m-danger,
+table.m-table td.m-info, table.m-table th.m-info,
+table.m-table td.m-dim, table.m-table th.m-dim {
+  padding-left: 0.4375rem;
+  padding-right: 0.4375rem;
+  border-left-width: 0.0625rem;
+}
+table.m-table.m-big td.m-default, table.m-table.m-big th.m-default,
+table.m-table.m-big td.m-primary, table.m-table.m-big th.m-primary,
+table.m-table.m-big td.m-success, table.m-table.m-big th.m-success,
+table.m-table.m-big td.m-warning, table.m-table.m-big th.m-warning,
+table.m-table.m-big td.m-danger, table.m-table.m-big th.m-danger,
+table.m-table.m-big td.m-info, table.m-table.m-big th.m-info,
+table.m-table.m-big td.m-dim, table.m-table.m-big th.m-dim {
+  padding-left: 0.9375rem;
+  padding-right: 0.9375rem;
+  border-left-width: 0.0625rem;
+}
+table.m-table tr.m-default td, table.m-table td.m-default,
+table.m-table tr.m-default th, table.m-table th.m-default,
+table.m-table tr.m-primary td, table.m-table td.m-primary,
+table.m-table tr.m-primary th, table.m-table th.m-primary,
+table.m-table tr.m-success td, table.m-table td.m-success,
+table.m-table tr.m-success th, table.m-table th.m-success,
+table.m-table tr.m-warning td, table.m-table td.m-warning,
+table.m-table tr.m-warning th, table.m-table th.m-warning,
+table.m-table tr.m-danger td, table.m-table td.m-danger,
+table.m-table tr.m-danger th, table.m-table th.m-danger,
+table.m-table tr.m-info td, table.m-table td.m-info,
+table.m-table tr.m-info th, table.m-table th.m-info,
+table.m-table tr.m-dim td, table.m-table td.m-dim,
+table.m-table tr.m-dim th, table.m-table th.m-dim {
+  border-color: #2f363f;
+}
+.m-note pre, .m-note code,
+table.m-table tr.m-default pre, table.m-table tr.m-default code,
+table.m-table td.m-default pre, table.m-table td.m-default code,
+table.m-table th.m-default pre, table.m-table th.m-default code,
+table.m-table tr.m-primary pre, table.m-table tr.m-primary code,
+table.m-table td.m-primary pre, table.m-table td.m-primary code,
+table.m-table th.m-primary pre, table.m-table th.m-primary code,
+table.m-table tr.m-success pre, table.m-table tr.m-success code,
+table.m-table td.m-success pre, table.m-table td.m-success code,
+table.m-table th.m-success pre, table.m-table th.m-success code,
+table.m-table tr.m-warning pre, table.m-table tr.m-warning code,
+table.m-table td.m-warning pre, table.m-table td.m-warning code,
+table.m-table th.m-warning pre, table.m-table th.m-warning code,
+table.m-table tr.m-danger pre, table.m-table tr.m-danger code,
+table.m-table td.m-danger pre, table.m-table td.m-danger code,
+table.m-table th.m-danger pre, table.m-table th.m-danger code,
+table.m-table tr.m-info pre, table.m-table tr.m-info code,
+table.m-table td.m-info pre, table.m-table td.m-info code,
+table.m-table th.m-info pre, table.m-table th.m-info code,
+table.m-table tr.m-dim pre, table.m-table tr.m-dim code,
+table.m-table td.m-dim pre, table.m-table td.m-dim code,
+table.m-table th.m-dim pre, table.m-table th.m-dim code {
+  background-color: rgba(34, 39, 46, 0.5);
+}
+img.m-image, svg.m-image {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+div.m-image {
+  text-align: center;
+}
+img.m-image, svg.m-image, div.m-image img, div.m-image svg {
+  max-width: 100%;
+  border-radius: 0.2rem;
+}
+div.m-image.m-fullwidth img, div.m-image.m-fullwidth svg {
+  width: 100%;
+}
+figure.m-figure {
+  max-width: 100%;
+  margin-top: 0;
+  margin-left: auto;
+  margin-right: auto;
+  position: relative;
+  display: table;
+}
+figure.m-figure:before {
+  position: absolute;
+  content: ' ';
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: -1;
+  border-style: solid;
+  border-width: 0.125rem;
+  border-radius: 0.2rem;
+  border-color: #405363;
+}
+figure.m-figure.m-flat:before {
+  border-color: transparent;
+}
+figure.m-figure > * {
+  margin-left: 1rem;
+  margin-right: 1rem;
+  display: table-caption;
+  caption-side: bottom;
+}
+figure.m-figure > *:first-child {
+  display: inline;
+}
+figure.m-figure > *:last-child {
+  margin-bottom: 1rem !important;
+}
+figure.m-figure img, figure.m-figure svg {
+  position: relative;
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  border-top-left-radius: 0.2rem;
+  border-top-right-radius: 0.2rem;
+  max-width: 100%;
+}
+figure.m-figure.m-flat img, figure.m-figure.m-flat svg {
+  border-bottom-left-radius: 0.2rem;
+  border-bottom-right-radius: 0.2rem;
+}
+figure.m-figure a img, figure.m-figure a svg {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+figure.m-figure.m-fullwidth, figure.m-figure.m-fullwidth > * {
+  display: block;
+}
+figure.m-figure.m-fullwidth > *:first-child {
+  display: inline;
+}
+figure.m-figure.m-fullwidth img, figure.m-figure.m-fullwidth svg {
+  width: 100%;
+}
+figure.m-figure.m-fullwidth:after {
+  content: ' ';
+  display: block;
+  margin-top: 1rem;
+  height: 1px;
+}
+.m-code-figure, .m-console-figure {
+  margin-top: 0;
+  margin-left: 0;
+  margin-right: 0;
+  position: relative;
+  padding: 1rem;
+}
+.m-code-figure:before, .m-console-figure:before {
+  position: absolute;
+  content: ' ';
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: -1;
+  border-style: solid;
+  border-width: 0.125rem;
+  border-radius: 0.2rem;
+}
+.m-code-figure:before {
+  border-color: #282e36;
+}
+.m-console-figure:before {
+  border-color: #161616;
+}
+.m-code-figure.m-flat:before, .m-console-figure.m-flat:before {
+  border-color: transparent;
+}
+.m-code-figure > pre:first-child, .m-console-figure > pre:first-child {
+  position: relative;
+  margin: -1rem -1rem 1rem -1rem;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.m-code-figure > pre.m-nopad, .m-console-figure > pre.m-nopad {
+  margin-left: -0.875rem;
+  margin-right: -0.875rem;
+  margin-top: -1rem;
+  margin-bottom: -0.875rem;
+  padding-left: 0.875rem;
+}
+figure.m-figure figcaption, .m-code-figure figcaption, .m-console-figure figcaption {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  font-size: 1.17rem;
+}
+.m-imagegrid > div {
+  background-color: #2f363f;
+}
+.m-imagegrid > div > figure {
+  display: block;
+  float: left;
+  position: relative;
+  margin: 0;
+}
+.m-imagegrid > div > figure > div,
+.m-imagegrid > div > figure > figcaption,
+.m-imagegrid > div > figure > a > div,
+.m-imagegrid > div > figure > a > figcaption {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-color: #2f363f;
+  border-style: solid;
+  border-width: 0.25rem;
+  padding: 0.5rem;
+}
+.m-imagegrid > div > figure:first-child > div,
+.m-imagegrid > div > figure:first-child > figcaption,
+.m-imagegrid > div > figure:first-child > a > div,
+.m-imagegrid > div > figure:first-child > a > figcaption {
+  border-left-width: 0;
+}
+.m-imagegrid > div > figure:last-child > div,
+.m-imagegrid > div > figure:last-child > figcaption,
+.m-imagegrid > div > figure:last-child > a > div,
+.m-imagegrid > div > figure:last-child > a > figcaption {
+  border-right-width: 0;
+}
+.m-imagegrid > div > figure > figcaption,
+.m-imagegrid > div > figure > a > figcaption {
+  color: transparent;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.75rem;
+}
+.m-imagegrid > div > figure > div::before,
+.m-imagegrid > div > figure > figcaption::before,
+.m-imagegrid > div > figure > a > div::before,
+.m-imagegrid > div > figure > a > figcaption::before {
+  content: '';
+  display: inline-block;
+  height: 100%;
+  vertical-align: bottom;
+  width: 0;
+}
+.m-imagegrid > div > figure:hover > figcaption,
+.m-imagegrid > div > figure:hover > a > figcaption {
+  background: linear-gradient(transparent 0%, transparent 75%, rgba(0, 0, 0, 0.85) 100%);
+  color: #ffffff;
+}
+.m-imagegrid > div > figure > img,
+.m-imagegrid > div > figure > a > img {
+  width: 100%;
+  height: 100%;
+}
+.m-imagegrid > div::after {
+  display: block;
+  content: ' ';
+  clear: both;
+}
+@media screen and (max-width: 767px) {
+  .m-imagegrid > div > figure {
+    float: none;
+    width: 100% !important;
+  }
+  .m-imagegrid > div > figure > div,
+  .m-imagegrid > div > figure > figcaption,
+  .m-imagegrid > div > figure > a > div,
+  .m-imagegrid > div > figure > a > figcaption {
+    border-left-width: 0;
+    border-right-width: 0;
+  }
+}
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-note,
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-frame,
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-block,
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-imagegrid,
+.m-container-inflatable > .m-row > [class*='m-col-'] > pre,
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-code-figure,
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-console-figure,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-note,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-frame,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-block,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-imagegrid,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > pre,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-code-figure,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-console-figure,
+.m-container-inflatable [class*='m-center-'] > .m-note,
+.m-container-inflatable [class*='m-center-'] > .m-frame,
+.m-container-inflatable [class*='m-center-'] > .m-block,
+.m-container-inflatable [class*='m-center-'] > .m-imagegrid,
+.m-container-inflatable [class*='m-center-'] > pre,
+.m-container-inflatable [class*='m-center-'] > .m-code-figure,
+.m-container-inflatable [class*='m-center-'] > .m-console-figure,
+.m-container-inflatable [class*='m-left-'] > .m-note,
+.m-container-inflatable [class*='m-left-'] > .m-frame,
+.m-container-inflatable [class*='m-left-'] > .m-block,
+.m-container-inflatable [class*='m-left-'] > .m-imagegrid,
+.m-container-inflatable [class*='m-left-'] > pre,
+.m-container-inflatable [class*='m-left-'] > .m-code-figure,
+.m-container-inflatable [class*='m-left-'] > .m-console-figure,
+.m-container-inflatable [class*='m-right-'] > .m-note,
+.m-container-inflatable [class*='m-right-'] > .m-frame,
+.m-container-inflatable [class*='m-right-'] > .m-block,
+.m-container-inflatable [class*='m-right-'] > .m-imagegrid,
+.m-container-inflatable [class*='m-right-'] > pre,
+.m-container-inflatable [class*='m-right-'] > .m-code-figure,
+.m-container-inflatable [class*='m-right-'] > .m-console-figure,
+.m-container-inflatable .m-container-inflate > .m-note,
+.m-container-inflatable .m-container-inflate > .m-frame,
+.m-container-inflatable .m-container-inflate > .m-block,
+.m-container-inflatable .m-container-inflate > .m-imagegrid,
+.m-container-inflatable .m-container-inflate > pre,
+.m-container-inflatable .m-container-inflate > .m-code-figure,
+.m-container-inflatable .m-container-inflate > .m-console-figure
+{
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+@media screen and (min-width: 576px) {
+  .m-container-inflatable .m-center-s > .m-note,
+  .m-container-inflatable .m-center-s > .m-frame,
+  .m-container-inflatable .m-center-s > .m-block,
+  .m-container-inflatable .m-center-s > .m-imagegrid,
+  .m-container-inflatable .m-center-s > pre,
+  .m-container-inflatable .m-center-s > .m-code-figure,
+  .m-container-inflatable .m-center-s > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable .m-left-s > .m-note,
+  .m-container-inflatable .m-left-s > .m-frame,
+  .m-container-inflatable .m-left-s > .m-block,
+  .m-container-inflatable .m-left-s > .m-imagegrid,
+  .m-container-inflatable .m-left-s > pre,
+  .m-container-inflatable .m-left-s > .m-code-figure,
+  .m-container-inflatable .m-left-s > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: 0;
+  }
+  .m-container-inflatable .m-right-s > .m-note,
+  .m-container-inflatable .m-right-s > .m-frame,
+  .m-container-inflatable .m-right-s > .m-block,
+  .m-container-inflatable .m-right-s > .m-imagegrid,
+  .m-container-inflatable .m-right-s > pre,
+  .m-container-inflatable .m-right-s > .m-code-figure,
+  .m-container-inflatable .m-right-s > .m-console-figure {
+    margin-left: 0;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable > .m-row > .m-col-s-10 > .m-imagegrid.m-container-inflate,
+  .m-container-inflatable > .m-row > .m-col-s-10 section > .m-imagegrid.m-container-inflate {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+}
+@media screen and (min-width: 768px) {
+  .m-container-inflatable .m-center-m > .m-note,
+  .m-container-inflatable .m-center-m > .m-frame,
+  .m-container-inflatable .m-center-m > .m-block,
+  .m-container-inflatable .m-center-m > .m-imagegrid,
+  .m-container-inflatable .m-center-m > pre,
+  .m-container-inflatable .m-center-m > .m-code-figure,
+  .m-container-inflatable .m-center-m > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable .m-left-m > .m-note,
+  .m-container-inflatable .m-left-m > .m-frame,
+  .m-container-inflatable .m-left-m > .m-block,
+  .m-container-inflatable .m-left-m > .m-imagegrid,
+  .m-container-inflatable .m-left-m > pre,
+  .m-container-inflatable .m-left-m > .m-code-figure,
+  .m-container-inflatable .m-left-m > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: 0;
+  }
+  .m-container-inflatable .m-right-m > .m-note,
+  .m-container-inflatable .m-right-m > .m-frame,
+  .m-container-inflatable .m-right-m > .m-block,
+  .m-container-inflatable .m-right-m > .m-imagegrid,
+  .m-container-inflatable .m-right-m > pre,
+  .m-container-inflatable .m-right-m > .m-code-figure,
+  .m-container-inflatable .m-right-m > .m-console-figure {
+    margin-left: 0;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable > .m-row > .m-col-m-10 > .m-imagegrid.m-container-inflate,
+  .m-container-inflatable > .m-row > .m-col-m-10 section > .m-imagegrid.m-container-inflate {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+}
+@media screen and (min-width: 992px) {
+  .m-container-inflatable .m-center-l > .m-note,
+  .m-container-inflatable .m-center-l > .m-frame,
+  .m-container-inflatable .m-center-l > .m-block,
+  .m-container-inflatable .m-center-l > .m-imagegrid,
+  .m-container-inflatable .m-center-l > pre,
+  .m-container-inflatable .m-center-l > .m-code-figure,
+  .m-container-inflatable .m-center-l > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable .m-left-l > .m-note,
+  .m-container-inflatable .m-left-l > .m-frame,
+  .m-container-inflatable .m-left-l > .m-block,
+  .m-container-inflatable .m-left-l > .m-imagegrid,
+  .m-container-inflatable .m-left-l > pre,
+  .m-container-inflatable .m-left-l > .m-code-figure,
+  .m-container-inflatable .m-left-l > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: 0;
+  }
+  .m-container-inflatable .m-right-l > .m-note,
+  .m-container-inflatable .m-right-l > .m-frame,
+  .m-container-inflatable .m-right-l > .m-block,
+  .m-container-inflatable .m-right-l > .m-imagegrid,
+  .m-container-inflatable .m-right-l > pre,
+  .m-container-inflatable .m-right-l > .m-code-figure,
+  .m-container-inflatable .m-right-l > .m-console-figure {
+    margin-left: 0;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable > .m-row > .m-col-l-10 > .m-imagegrid.m-container-inflate,
+  .m-container-inflatable > .m-row > .m-col-l-10 section > .m-imagegrid.m-container-inflate {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+}
+pre.m-code span.hll {
+  margin-left: -1.0rem;
+  margin-right: -1.0rem;
+  padding-left: 1.0rem;
+}
+.m-code.m-inverted {
+  color: rgba(230, 230, 230, 0.33);
+}
+.m-code.m-inverted > span {
+  opacity: 0.3333;
+}
+.m-code.m-inverted > span.hll {
+  color: #dcdcdc;
+  opacity: 1;
+  background-color: transparent;
+  border-color: transparent;
+}
+.m-code-color {
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  vertical-align: -0.05rem;
+  margin-left: 0.2rem;
+  margin-right: 0.1rem;
+  border-radius: 0.1rem;
+}
+div.m-math {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+div.m-math svg {
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+div.m-button a svg.m-math { fill: #22272e; }
+div.m-button.m-flat a svg.m-math { fill: #dcdcdc; }
+div.m-button.m-flat a:hover svg.m-math, div.m-button.m-default a:focus svg.m-math,
+div.m-button.m-default a:active svg.m-math {
+  fill: #a5c9ea;
+}
+.m-graph { font-size: 16px; }
+div.m-plot svg, div.m-graph svg {
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+div.m-plot .m-background { fill: #34424d; }
+div.m-plot svg .m-label { font-size: 11px; }
+div.m-plot svg .m-title { font-size: 13px; }
+div.m-plot svg .m-label, div.m-plot svg .m-title { fill: #dcdcdc; }
+div.m-plot svg .m-line {
+  stroke: #dcdcdc;
+  stroke-width: 0.8;
+}
+div.m-plot svg .m-error {
+  stroke: #ffffff;
+  stroke-width: 1.5;
+}
+div.m-plot svg .m-label.m-dim { fill: #747474; }
+.m-graph g.m-edge path, .m-graph g.m-node.m-flat ellipse,
+.m-graph g.m-node.m-flat polygon {
+  fill: none;
+}
+.m-graph g.m-node:not(.m-flat) text {
+  fill: #22272e;
+}
+figure.m-figure > svg.m-math:first-child,
+figure.m-figure > svg.m-graph:first-child {
+  padding: 1rem;
+  box-sizing: content-box;
+}
+figure.m-figure:not(.m-flat) > svg.m-math:first-child,
+figure.m-figure:not(.m-flat) > svg.m-graph:first-child {
+  background-color: #405363;
+}
+.m-block.m-default { border-left-color: #405363; }
+.m-block.m-default h3, .m-block.m-default h4, .m-block.m-default h5, .m-block.m-default h6,
+.m-text.m-default, .m-label.m-flat.m-default {
+  color: #dcdcdc;
+}
+.m-block.m-default h3 a, .m-block.m-default h4 a, .m-block.m-default h5 a, .m-block.m-default h6 a {
+  color: #5b9dd9;
+}
+.m-block.m-primary { border-left-color: #a5c9ea; }
+.m-block.m-primary h3, .m-block.m-primary h4, .m-block.m-primary h5, .m-block.m-primary h6,
+.m-block.m-primary h3 a, .m-block.m-primary h4 a, .m-block.m-primary h5 a, .m-block.m-primary h6 a,
+.m-text.m-primary, .m-label.m-flat.m-primary {
+  color: #a5c9ea;
+}
+.m-block.m-success { border-left-color: #3bd267; }
+.m-block.m-success h3, .m-block.m-success h4, .m-block.m-success h5, .m-block.m-success h6,
+.m-block.m-success h3 a, .m-block.m-success h4 a, .m-block.m-success h5 a, .m-block.m-success h6 a,
+.m-text.m-success, .m-label.m-flat.m-success {
+  color: #3bd267;
+}
+.m-block.m-warning { border-left-color: #c7cf2f; }
+.m-block.m-warning h3, .m-block.m-warning h4, .m-block.m-warning h5, .m-block.m-warning h6,
+.m-block.m-warning h3 a, .m-block.m-warning h4 a, .m-block.m-warning h5 a, .m-block.m-warning h6 a,
+.m-text.m-warning, .m-label.m-flat.m-warning {
+  color: #c7cf2f;
+}
+.m-block.m-danger { border-left-color: #cd3431; }
+.m-block.m-danger h3, .m-block.m-danger h4, .m-block.m-danger h5, .m-block.m-danger h6,
+.m-block.m-danger h3 a, .m-block.m-danger h4 a, .m-block.m-danger h5 a, .m-block.m-danger h6 a,
+.m-text.m-danger, .m-label.m-flat.m-danger {
+  color: #cd3431;
+}
+.m-block.m-info { border-left-color: #2f83cc; }
+.m-block.m-info h3, .m-block.m-info h4, .m-block.m-info h5, .m-block.m-info h6,
+.m-block.m-info h3 a, .m-block.m-info h4 a, .m-block.m-info h5 a, .m-block.m-info h6 a,
+.m-text.m-info, .m-label.m-flat.m-info {
+  color: #2f83cc;
+}
+.m-block.m-dim { border-left-color: #747474; }
+.m-block.m-dim, .m-text.m-dim, .m-label.m-flat.m-dim {
+  color: #747474;
+}
+.m-block.m-dim a, .m-text.m-dim a { color: #acacac; }
+.m-block.m-dim a:hover, .m-block.m-dim a:focus, .m-block.m-dim a:active,
+.m-text.m-dim a:hover, .m-text.m-dim a:focus, .m-text.m-dim a:active {
+  color: #747474;
+}
+.m-block.m-flat { border-color: transparent; }
+.m-block.m-flat h3, .m-block.m-flat h4, .m-block.m-flat h5. .m-block.m-flat h6 {
+  color: #dcdcdc;
+}
+.m-block.m-default h3 a:hover, .m-block.m-default h3 a:focus, .m-block.m-default h3 a:active,
+.m-block.m-default h4 a:hover, .m-block.m-default h4 a:focus, .m-block.m-default h4 a:active,
+.m-block.m-default h5 a:hover, .m-block.m-default h5 a:focus, .m-block.m-default h5 a:active,
+.m-block.m-default h6 a:hover, .m-block.m-default h6 a:focus, .m-block.m-default h6 a:active {
+  color: #a5c9ea;
+}
+.m-block.m-primary h3 a:hover, .m-block.m-primary h3 a:focus, .m-block.m-primary h3 a:active,
+.m-block.m-primary h4 a:hover, .m-block.m-primary h4 a:focus, .m-block.m-primary h4 a:active,
+.m-block.m-primary h5 a:hover, .m-block.m-primary h5 a:focus, .m-block.m-primary h5 a:active,
+.m-block.m-primary h6 a:hover, .m-block.m-primary h6 a:focus, .m-block.m-primary h6 a:active {
+  color: #dcdcdc;
+}
+.m-block.m-success h3 a:hover, .m-block.m-success h3 a:focus, .m-block.m-success h3 a:active,
+.m-block.m-success h4 a:hover, .m-block.m-success h4 a:focus, .m-block.m-success h4 a:active,
+.m-block.m-success h5 a:hover, .m-block.m-success h5 a:focus, .m-block.m-success h5 a:active,
+.m-block.m-success h6 a:hover, .m-block.m-success h6 a:focus, .m-block.m-success h6 a:active {
+  color: #acecbe;
+}
+.m-block.m-warning h3 a:hover, .m-block.m-warning h3 a:focus, .m-block.m-warning h3 a:active,
+.m-block.m-warning h4 a:hover, .m-block.m-warning h4 a:focus, .m-block.m-warning h4 a:active,
+.m-block.m-warning h5 a:hover, .m-block.m-warning h5 a:focus, .m-block.m-warning h5 a:active,
+.m-block.m-warning h6 a:hover, .m-block.m-warning h6 a:focus, .m-block.m-warning h6 a:active {
+  color: #e9ecae;
+}
+.m-block.m-danger h3 a:hover, .m-block.m-danger h3 a:focus, .m-block.m-danger h3 a:active,
+.m-block.m-danger h4 a:hover, .m-block.m-danger h4 a:focus, .m-block.m-danger h4 a:active,
+.m-block.m-danger h5 a:hover, .m-block.m-danger h5 a:focus, .m-block.m-danger h5 a:active,
+.m-block.m-danger h6 a:hover, .m-block.m-danger h6 a:focus, .m-block.m-danger h6 a:active {
+  color: #ff9391;
+}
+.m-block.m-info h3 a:hover, .m-block.m-info h3 a:focus, .m-block.m-info h3 a:active,
+.m-block.m-info h4 a:hover, .m-block.m-info h4 a:focus, .m-block.m-info h4 a:active,
+.m-block.m-info h5 a:hover, .m-block.m-info h5 a:focus, .m-block.m-info h5 a:active,
+.m-block.m-info h6 a:hover, .m-block.m-info h6 a:focus, .m-block.m-info h6 a:active {
+  color: #5297d7;
+}
+div.m-button a, .m-label { color: #22272e; }
+div.m-button.m-flat a { color: #dcdcdc; }
+div.m-button.m-flat a:hover, div.m-button.m-default a:focus, div.m-button.m-default a:active {
+  color: #a5c9ea;
+}
+div.m-button.m-default a, .m-label:not(.m-flat).m-default { background-color: #dcdcdc; }
+div.m-button.m-primary a, .m-label:not(.m-flat).m-primary { background-color: #a5c9ea; }
+div.m-button.m-success a, .m-label:not(.m-flat).m-success { background-color: #3bd267; }
+div.m-button.m-warning a, .m-label:not(.m-flat).m-warning { background-color: #c7cf2f; }
+div.m-button.m-danger a, .m-label:not(.m-flat).m-danger { background-color: #cd3431; }
+div.m-button.m-info a, .m-label:not(.m-flat).m-info { background-color: #2f83cc; }
+div.m-button.m-dim a, .m-label:not(.m-flat).m-dim { background-color: #747474; }
+div.m-button.m-default a:hover, div.m-button.m-default a:focus, div.m-button.m-default a:active {
+  background-color: #a5c9ea;
+}
+div.m-button.m-primary a:hover, div.m-button.m-primary a:focus, div.m-button.m-primary a:active {
+  background-color: #dcdcdc;
+}
+div.m-button.m-success a:hover, div.m-button.m-success a:focus, div.m-button.m-success a:active {
+  background-color: #acecbe;
+}
+div.m-button.m-warning a:hover, div.m-button.m-warning a:focus, div.m-button.m-warning a:active {
+  background-color: #e9ecae;
+}
+div.m-button.m-danger a:hover, div.m-button.m-danger a:focus, div.m-button.m-danger a:active {
+  background-color: #ff9391;
+}
+div.m-button.m-info a:hover, div.m-button.m-info a:focus, div.m-button.m-info a:active {
+  background-color: #5297d7;
+}
+div.m-button.m-dim a:hover, div.m-button.m-dim a:focus, div.m-button.m-dim a:active {
+  background-color: #acacac;
+}
+.m-note.m-default { background-color: #34424d; }
+.m-note.m-default,
+table.m-table tr.m-default td, table.m-table td.m-default,
+table.m-table tr.m-default th, table.m-table th.m-default {
+  color: #dcdcdc;
+}
+.m-note.m-default a:hover,
+table.m-table tr.m-default td a:hover, table.m-table td.m-default a:hover,
+table.m-table tr.m-default th a:hover, table.m-table th.m-default a:hover,
+.m-note.m-default a:focus,
+table.m-table tr.m-default td a:focus, table.m-table td.m-default a:focus,
+table.m-table tr.m-default th a:focus, table.m-table th.m-default a:focus,
+.m-note.m-default a:active,
+table.m-table tr.m-default td a:active, table.m-table td.m-default a:active,
+table.m-table tr.m-default th a:active, table.m-table th.m-default a:active {
+  color: #a5c9ea;
+}
+.m-note.m-primary a,
+table.m-table tr.m-primary td a, table.m-table td.m-primary a,
+table.m-table tr.m-primary th a, table.m-table th.m-primary a {
+  color: #5b9dd9;
+}
+.m-note.m-primary,
+table.m-table tr.m-primary td, table.m-table td.m-primary,
+table.m-table tr.m-primary th, table.m-table th.m-primary {
+  background-color: #a5c2db;
+  color: #2f363f;
+}
+.m-note.m-primary a,
+table.m-table tr.m-primary td a, table.m-table td.m-primary a,
+table.m-table tr.m-primary th a, table.m-table th.m-primary a {
+  color: #2a75b6;
+}
+.m-note.m-primary a:hover,
+table.m-table tr.m-primary td a:hover, table.m-table td.m-primary a:hover,
+table.m-table tr.m-primary th a:hover, table.m-table th.m-primary a:hover,
+.m-note.m-primary a:focus,
+table.m-table tr.m-primary td a:focus, table.m-table td.m-primary a:focus,
+table.m-table tr.m-primary th a:focus, table.m-table th.m-primary a:focus,
+.m-note.m-primary a:active,
+table.m-table tr.m-primary td a:active, table.m-table td.m-primary a:active,
+table.m-table tr.m-primary th a:active, table.m-table th.m-primary a:active {
+  color: #2f363f;
+}
+.m-note.m-success,
+table.m-table tr.m-success td, table.m-table td.m-success,
+table.m-table tr.m-success th, table.m-table th.m-success {
+  background-color: #2a703f;
+  color: #acecbe;
+}
+.m-note.m-success a,
+table.m-table tr.m-success td a, table.m-table td.m-success a,
+table.m-table tr.m-success th a, table.m-table th.m-success a {
+  color: #3bd267;
+}
+.m-note.m-success a:hover,
+table.m-table tr.m-success td a:hover, table.m-table td.m-success a:hover,
+table.m-table tr.m-success th a:hover, table.m-table th.m-success a:hover,
+.m-note.m-success a:focus,
+table.m-table tr.m-success td a:focus, table.m-table td.m-success a:focus,
+table.m-table tr.m-success th a:focus, table.m-table th.m-success a:focus,
+.m-note.m-success a:active,
+table.m-table tr.m-success td a:active, table.m-table td.m-success a:active,
+table.m-table tr.m-success th a:active, table.m-table th.m-success a:active {
+  color: #acecbe;
+}
+.m-note.m-warning, table.m-table tr.m-warning td, table.m-table td.m-warning,
+                   table.m-table tr.m-warning th, table.m-table th.m-warning {
+  background-color: #6d702a;
+  color: #e9ecae;
+}
+.m-note.m-warning a, table.m-table tr.m-warning td a, table.m-table td.m-warning a,
+                     table.m-table tr.m-warning th a, table.m-table th.m-warning a {
+  color: #b8bf2b;
+}
+.m-note.m-warning a:hover,
+table.m-table tr.m-warning td a:hover, table.m-table td.m-warning a:hover,
+table.m-table tr.m-warning th a:hover, table.m-table th.m-warning a:hover,
+.m-note.m-warning a:focus,
+table.m-table tr.m-warning td a:focus, table.m-table td.m-warning a:focus,
+table.m-table tr.m-warning th a:focus, table.m-table th.m-warning a:focus,
+.m-note.m-warning a:active,
+table.m-table tr.m-warning td a:active, table.m-table td.m-warning a:active,
+table.m-table tr.m-warning th a:active, table.m-table th.m-warning a:active {
+  color: #e9ecae;
+}
+.m-note.m-danger,
+table.m-table tr.m-danger td, table.m-table td.m-danger,
+table.m-table tr.m-danger th, table.m-table th.m-danger {
+  background-color: #702b2a;
+  color: #ff9391;
+}
+.m-note.m-danger a,
+table.m-table tr.m-danger td a, table.m-table td.m-danger a,
+table.m-table tr.m-danger th a, table.m-table th.m-danger a {
+  color: #d85c59;
+}
+.m-note.m-danger a:hover,
+table.m-table tr.m-danger td a:hover, table.m-table td.m-danger a:hover,
+table.m-table tr.m-danger th a:hover, table.m-table th.m-danger a:hover,
+.m-note.m-danger a:focus,
+table.m-table tr.m-danger td a:focus, table.m-table td.m-danger a:focus,
+table.m-table tr.m-danger th a:focus, table.m-table th.m-danger a:focus,
+.m-note.m-danger a:active,
+table.m-table tr.m-danger td a:active, table.m-table td.m-danger a:active,
+table.m-table tr.m-danger th a:active, table.m-table th.m-danger a:active {
+  color: #ff9391;
+}
+.m-note.m-info,
+table.m-table tr.m-info td, table.m-table td.m-info,
+table.m-table tr.m-info th, table.m-table th.m-info {
+  background-color: #2a4f70;
+  color: #a5caeb;
+}
+.m-note.m-info a,
+table.m-table tr.m-info td a, table.m-table td.m-info a,
+table.m-table tr.m-info th a, table.m-table th.m-info a {
+  color: #5297d7;
+}
+.m-note.m-info a:hover,
+table.m-table tr.m-info td a:hover, table.m-table td.m-info a:hover,
+table.m-table tr.m-info th a:hover, table.m-table th.m-info a:hover,
+.m-note.m-info a:focus,
+table.m-table tr.m-info td a:focus, table.m-table td.m-info a:focus,
+table.m-table tr.m-info th a:focus, table.m-table th.m-info a:focus,
+.m-note.m-info a:active,
+table.m-table tr.m-info td a:active, table.m-table td.m-info a:active,
+table.m-table tr.m-info th a:active, table.m-table th.m-info a:active {
+  color: #a5caeb;
+}
+.m-note.m-dim,
+table.m-table tr.m-dim td, table.m-table td.m-dim,
+table.m-table tr.m-dim th, table.m-table th.m-dim {
+  background-color: #2d3236;
+  color: #747474;
+}
+.m-note.m-dim a,
+table.m-table tr.m-dim td a, table.m-table td.m-dim a,
+table.m-table tr.m-dim th a, table.m-table th.m-dim a {
+  color: #acacac;
+}
+.m-note.m-dim a:hover,
+table.m-table tr.m-dim td a:hover, table.m-table td.m-dim a:hover,
+table.m-table tr.m-dim th a:hover, table.m-table th.m-dim a:hover,
+.m-note.m-dim a:focus,
+table.m-table tr.m-dim td a:focus, table.m-table td.m-dim a:focus,
+table.m-table tr.m-dim th a:focus, table.m-table th.m-dim a:focus,
+.m-note.m-dim a:active,
+table.m-table tr.m-dim td a:active, table.m-table td.m-dim a:active,
+table.m-table tr.m-dim th a:active, table.m-table th.m-dim a:active {
+  color: #747474;
+}
+figure.m-figure.m-default:before { border-color: #34424d; }
+figure.m-figure.m-default figcaption { color: #dcdcdc; }
+figure.m-figure.m-primary:before { border-color: #a5c2db; }
+figure.m-figure.m-primary figcaption { color: #a5c9ea; }
+figure.m-figure.m-success:before { border-color: #2a703f; }
+figure.m-figure.m-success figcaption { color: #3bd267; }
+figure.m-figure.m-warning:before { border-color: #6d702a; }
+figure.m-figure.m-warning figcaption { color: #c7cf2f; }
+figure.m-figure.m-danger:before { border-color: #702b2a; }
+figure.m-figure.m-danger figcaption { color: #cd3431; }
+figure.m-figure.m-info:before { border-color: #2a4f70; }
+figure.m-figure.m-info figcaption { color: #2f83cc; }
+figure.m-figure.m-dim:before { border-color: #2d3236; }
+figure.m-figure.m-dim { color: #747474; }
+figure.m-figure.m-dim a { color: #acacac; }
+figure.m-figure.m-dim a:hover, figure.m-figure.m-dim a:focus, figure.m-figure.m-dim a:active {
+  color: #747474;
+}
+.m-math { fill: #dcdcdc; }
+.m-math.m-default, .m-math g.m-default, .m-math rect.m-default,
+div.m-plot svg .m-bar.m-default,
+.m-graph g.m-edge polygon,
+.m-graph g.m-node:not(.m-flat) ellipse,
+.m-graph g.m-node:not(.m-flat) polygon,
+.m-graph g.m-edge text,
+.m-graph g.m-node.m-flat text,
+.m-graph.m-default g.m-edge polygon,
+.m-graph.m-default g.m-node:not(.m-flat) ellipse,
+.m-graph.m-default g.m-node:not(.m-flat) polygon,
+.m-graph.m-default g.m-edge text,
+.m-graph.m-default g.m-node.m-flat text {
+  fill: #dcdcdc;
+}
+.m-graph g.m-edge polygon,
+.m-graph g.m-edge path,
+.m-graph g.m-node ellipse,
+.m-graph g.m-node polygon,
+.m-graph g.m-node polyline,
+.m-graph.m-default g.m-edge polygon,
+.m-graph.m-default g.m-edge path,
+.m-graph.m-default g.m-node ellipse,
+.m-graph.m-default g.m-node polygon,
+.m-graph.m-default g.m-node polyline {
+  stroke: #dcdcdc;
+}
+.m-math.m-primary, .m-math g.m-primary, .m-math rect.m-primary,
+div.m-plot svg .m-bar.m-primary,
+.m-graph.m-primary g.m-edge polygon,
+.m-graph.m-primary g.m-node:not(.m-flat) ellipse,
+.m-graph.m-primary g.m-node:not(.m-flat) polygon,
+.m-graph.m-primary g.m-edge text,
+.m-graph.m-primary g.m-node.m-flat text {
+  fill: #a5c9ea;
+}
+.m-graph.m-primary g.m-edge polygon,
+.m-graph.m-primary g.m-edge path,
+.m-graph.m-primary g.m-node ellipse,
+.m-graph.m-primary g.m-node polygon,
+.m-graph.m-primary g.m-node polyline {
+  stroke: #a5c9ea;
+}
+.m-math.m-success, .m-math g.m-success, .m-math rect.m-success,
+div.m-plot svg .m-bar.m-success,
+.m-graph.m-success g.m-edge polygon,
+.m-graph.m-success g.m-node:not(.m-flat) ellipse,
+.m-graph.m-success g.m-node:not(.m-flat) polygon,
+.m-graph.m-success g.m-edge text,
+.m-graph.m-success g.m-node.m-flat text {
+  fill: #3bd267;
+}
+.m-graph.m-success g.m-edge polygon,
+.m-graph.m-success g.m-edge path,
+.m-graph.m-success g.m-node ellipse,
+.m-graph.m-success g.m-node polygon,
+.m-graph.m-success g.m-node polyline {
+  stroke: #3bd267;
+}
+.m-math.m-warning, .m-math g.m-warning, .m-math rect.m-warning,
+div.m-plot svg .m-bar.m-warning,
+.m-graph.m-warning g.m-edge polygon,
+.m-graph.m-warning g.m-node:not(.m-flat) ellipse,
+.m-graph.m-warning g.m-node:not(.m-flat) polygon,
+.m-graph.m-warning g.m-edge text,
+.m-graph.m-warning g.m-node.m-flat text {
+  fill: #c7cf2f;
+}
+.m-graph.m-warning g.m-edge polygon,
+.m-graph.m-warning g.m-edge path,
+.m-graph.m-warning g.m-node ellipse,
+.m-graph.m-warning g.m-node polygon,
+.m-graph.m-warning g.m-node polyline {
+  stroke: #c7cf2f;
+}
+.m-math.m-danger, .m-math g.m-danger, .m-math rect.m-danger,
+div.m-plot svg .m-bar.m-danger,
+.m-graph.m-danger g.m-edge polygon,
+.m-graph.m-danger g.m-node:not(.m-flat) ellipse,
+.m-graph.m-danger g.m-node:not(.m-flat) polygon,
+.m-graph.m-danger g.m-edge text,
+.m-graph.m-danger g.m-node.m-flat text {
+  fill: #cd3431;
+}
+.m-graph.m-danger g.m-edge polygon,
+.m-graph.m-danger g.m-edge path,
+.m-graph.m-danger g.m-node ellipse,
+.m-graph.m-danger g.m-node polygon,
+.m-graph.m-danger g.m-node polyline {
+  stroke: #cd3431;
+}
+.m-math.m-info, .m-math g.m-info, .m-math rect.m-info,
+div.m-plot svg .m-bar.m-info,
+.m-graph.m-info g.m-edge polygon,
+.m-graph.m-info g.m-node:not(.m-flat) ellipse,
+.m-graph.m-info g.m-node:not(.m-flat) polygon,
+.m-graph.m-info g.m-edge text,
+.m-graph.m-info g.m-node.m-flat text {
+  fill: #2f83cc;
+}
+.m-graph.m-info g.m-edge polygon,
+.m-graph.m-info g.m-edge path,
+.m-graph.m-info g.m-node ellipse,
+.m-graph.m-info g.m-node polygon,
+.m-graph.m-info g.m-node polyline {
+  stroke: #2f83cc;
+}
+.m-math.m-dim, .m-math g.m-dim, .m-math rect.m-dim,
+div.m-plot svg .m-bar.m-dim,
+.m-graph.m-dim g.m-edge polygon,
+.m-graph.m-dim g.m-node:not(.m-flat) ellipse,
+.m-graph.m-dim g.m-node:not(.m-flat) polygon,
+.m-graph.m-dim g.m-edge text,
+.m-graph.m-dim g.m-node.m-flat text {
+  fill: #747474;
+}
+.m-graph.m-dim g.m-edge polygon,
+.m-graph.m-dim g.m-edge path,
+.m-graph.m-dim g.m-node ellipse,
+.m-graph.m-dim g.m-node polygon,
+.m-graph.m-dim g.m-node polyline {
+  stroke: #747474;
+}
+.m-graph g.m-edge.m-default polygon,
+.m-graph g.m-node.m-default:not(.m-flat) ellipse,
+.m-graph g.m-node.m-default:not(.m-flat) polygon,
+.m-graph g.m-edge.m-default text,
+.m-graph g.m-node.m-default.m-flat text {
+  fill: #dcdcdc;
+}
+.m-graph g.m-edge.m-default polygon,
+.m-graph g.m-edge.m-default path,
+.m-graph g.m-node.m-default ellipse,
+.m-graph g.m-node.m-default polygon,
+.m-graph g.m-node.m-default polyline {
+  stroke: #dcdcdc;
+}
+.m-graph g.m-edge.m-primary polygon,
+.m-graph g.m-node.m-primary:not(.m-flat) ellipse,
+.m-graph g.m-node.m-primary:not(.m-flat) polygon,
+.m-graph g.m-edge.m-primary text,
+.m-graph g.m-node.m-primary.m-flat text {
+  fill: #a5c9ea;
+}
+.m-graph g.m-edge.m-primary polygon,
+.m-graph g.m-edge.m-primary path,
+.m-graph g.m-node.m-primary ellipse,
+.m-graph g.m-node.m-primary polygon,
+.m-graph g.m-node.m-primary polyline {
+  stroke: #a5c9ea;
+}
+.m-graph g.m-edge.m-success polygon,
+.m-graph g.m-node.m-success:not(.m-flat) ellipse,
+.m-graph g.m-node.m-success:not(.m-flat) polygon,
+.m-graph g.m-edge.m-success text,
+.m-graph g.m-node.m-success.m-flat text {
+  fill: #3bd267;
+}
+.m-graph g.m-edge.m-success polygon,
+.m-graph g.m-edge.m-success path,
+.m-graph g.m-node.m-success ellipse,
+.m-graph g.m-node.m-success polygon,
+.m-graph g.m-node.m-success polyline {
+  stroke: #3bd267;
+}
+.m-graph g.m-edge.m-warning polygon,
+.m-graph g.m-node.m-warning:not(.m-flat) ellipse,
+.m-graph g.m-node.m-warning:not(.m-flat) polygon,
+.m-graph g.m-edge.m-warning text,
+.m-graph g.m-node.m-warning.m-flat text {
+  fill: #c7cf2f;
+}
+.m-graph g.m-edge.m-warning polygon,
+.m-graph g.m-edge.m-warning path,
+.m-graph g.m-node.m-warning ellipse,
+.m-graph g.m-node.m-warning polygon,
+.m-graph g.m-node.m-warning polyline {
+  stroke: #c7cf2f;
+}
+.m-graph g.m-edge.m-danger polygon,
+.m-graph g.m-node.m-danger:not(.m-flat) ellipse,
+.m-graph g.m-node.m-danger:not(.m-flat) polygon,
+.m-graph g.m-edge.m-danger text,
+.m-graph g.m-node.m-danger.m-flat text {
+  fill: #cd3431;
+}
+.m-graph g.m-edge.m-danger polygon,
+.m-graph g.m-edge.m-danger path,
+.m-graph g.m-node.m-danger ellipse,
+.m-graph g.m-node.m-danger polygon,
+.m-graph g.m-node.m-danger polyline {
+  stroke: #cd3431;
+}
+.m-graph g.m-edge.m-info polygon,
+.m-graph g.m-node.m-info:not(.m-flat) ellipse,
+.m-graph g.m-node.m-info:not(.m-flat) polygon,
+.m-graph g.m-edge.m-info text,
+.m-graph g.m-node.m-info.m-flat text {
+  fill: #2f83cc;
+}
+.m-graph g.m-edge.m-info polygon,
+.m-graph g.m-edge.m-info path,
+.m-graph g.m-node.m-info ellipse,
+.m-graph g.m-node.m-info polygon,
+.m-graph g.m-node.m-info polyline {
+  stroke: #2f83cc;
+}
+.m-graph g.m-edge.m-dim polygon,
+.m-graph g.m-node.m-dim:not(.m-flat) ellipse,
+.m-graph g.m-node.m-dim:not(.m-flat) polygon,
+.m-graph g.m-edge.m-dim text,
+.m-graph g.m-node.m-dim.m-flat text {
+  fill: #747474;
+}
+.m-graph g.m-edge.m-dim polygon,
+.m-graph g.m-edge.m-dim path,
+.m-graph g.m-node.m-dim ellipse,
+.m-graph g.m-node.m-dim polygon,
+.m-graph g.m-node.m-dim polyline {
+  stroke: #747474;
+}
+p, ul, ol, dl, blockquote, pre, .m-code-figure, .m-console-figure, hr, .m-note,
+.m-frame, .m-block, div.m-button, div.m-scroll, table.m-table, div.m-image,
+img.m-image, svg.m-image, figure.m-figure, .m-imagegrid, div.m-math,
+div.m-graph, div.m-plot {
+  margin-bottom: 1rem;
+}
+p:last-child, p.m-nopadb, ul:last-child, ul.m-nopadb,
+ol:last-child, ol.m-nopadb, dl:last-child, dl.m-nopadb,
+blockquote:last-child, blockquote.m-nopadb, pre:last-child, pre.m-nopadb,
+.m-code-figure:last-child, .m-code-figure.m-nopadb,
+.m-console-figure:last-child, .m-console-figure.m-nopadb,
+hr:last-child, hr.m-nopadb, .m-note:last-child, .m-note.m-nopadb,
+.m-frame:last-child, .m-frame.m-nopadb, .m-block:last-child, .m-block.m-nopadb,
+div.m-button:last-child, div.m-button.m-nopadb,
+div.m-scroll:last-child, div.m-scroll.m-nopadb,
+table.m-table:last-child, table.m-table.m-nopadb,
+img.m-image:last-child, img.m-image.m-nopadb,
+svg.m-image:last-child, svg.m-image.m-nopadb,
+div.m-image:last-child, div.m-image.m-nopadb,
+figure.m-figure:last-child, figure.m-figure.m-nopadb,
+.m-imagegrid:last-child, .m-imagegrid.m-nopadb,
+div.m-math:last-child, div.m-math.m-nopadb,
+div.m-graph:last-child, div.m-graph.m-nopadb,
+div.m-plot:last-child, div.m-plot.m-nopadb {
+  margin-bottom: 0;
+}
+li > p:last-child, li > blockquote:last-child, li > pre:last-child,
+li > .m-code-figure:last-child, li > .m-console-figure:last-child,
+li > .m-note:last-child, li > .m-frame:last-child, li > .m-block:last-child,
+li > div.m-button:last-child, li > div.m-scroll:last-child, li > table.m-table:last-child,
+li > img.m-image:last-child, li > svg.m-image:last-child, li > div.m-image:last-child,
+li > figure.m-figure:last-child, li > div.m-math:last-child,
+li > div.m-graph:last-child, li > div.m-plot:last-child {
+  margin-bottom: 1rem;
+}
+li:last-child > p:last-child, li:last-child > p.m-nopadb,
+li:last-child > blockquote:last-child, li:last-child > blockquote.m-nopadb,
+li:last-child > pre:last-child, li:last-child > pre.m-nopadb,
+li:last-child > .m-code-figure:last-child, li:last-child > .m-code-figure.m-nopadb,
+li:last-child > .m-console-figure:last-child, li:last-child > .m-console-figure.m-nopadb,
+li:last-child > .m-note:last-child, li:last-child > .m-note.m-nopadb,
+li:last-child > .m-frame:last-child, li:last-child > .m-frame.m-nopadb,
+li:last-child > .m-block:last-child, li:last-child > .m-block.m-nopadb,
+li:last-child > div.m-button:last-child, li:last-child > div.m-button.m-nopadb,
+li:last-child > div.m-scroll:last-child, li:last-child > div.m-scroll.m-nopadb,
+li:last-child > table.m-table:last-child, li:last-child > table.m-table.m-nopadb,
+li:last-child > img.m-image:last-child, li:last-child > img.m-image.m-nopadb,
+li:last-child > svg.m-image:last-child, li:last-child > svg.m-image.m-nopadb,
+li:last-child > div.m-image:last-child, li:last-child > div.m-image.m-nopadb,
+li:last-child > figure.m-figure:last-child, li:last-child > figure.m-figure.m-nopadb,
+li:last-child > div.m-math:last-child, li:last-child > div.m-math.m-nopadb,
+li:last-child > div.m-graph:last-child, li:last-child > div.m-graph.m-nopadb,
+li:last-child > div.m-plot:last-child, li:last-child > div.m-plot.m-nopadb {
+  margin-bottom: 0;
+}
+
+html {
+  font-size: 2.49vw;
+  background-color: transparent;
+}
+article > aside, article > section {
+  height: 100vh;
+  padding: 1rem;
+}
+article > aside {
+  background-color: #22272e;
+}
+article > aside > h1 {
+  font-size: 4rem;
+  padding-top: 2rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-bottom: 2rem;
+}
+article > section {
+  position: relative;
+  background-color: #2f363f;
+}
+article > section.m-presentation-cover {
+  background-size: cover;
+  background-color: #22272e;
+  background-position: center center;
+  background-repeat: no-repeat;
+}
+article > section > h1 {
+  margin: -1rem;
+  padding-top: 7rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  height: 100vh;
+  font-size: 4rem;
+}
+article > section:not(.m-presentation-cover) > h1 {
+  background-color: #22272e;
+}
+article > section.m-presentation-cover > h1,
+article > section.m-presentation-cover > h2 {
+  color: #ffffff;
+}
+article > section.m-presentation-cover.m-inverted > h1,
+article > section.m-presentation-cover.m-inverted > h2 {
+  color: #000000;
+}
+article > section > h1 + h2 {
+  margin-top: -100vh;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  padding-top: 13rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  font-size: 2rem;
+}
+article > section > h2:first-child {
+  color: #a5c9ea;
+  line-height: 3.5rem;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  margin-top: -1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  margin-bottom: 1rem;
+  background-color: #22272e;
+}
+article > section.m-presentation-background > h2:first-child {
+  background-color: rgba(34, 39, 46, 0.25);
+}
+article > section > nav {
+  font-size: 85.4%;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  padding-bottom: 1.0rem;
+  padding-right: 0.5rem;
+}
+article > section > nav > a {
+  text-decoration: none;
+  display: inline-block;
+  width: 1.5rem;
+}
+article > section > nav > a:link, article > section > nav > a:visited {
+  color: #acacac;
+}
+article > section > nav > a:hover, article > section > nav > a:active {
+  color: #747474;
+}
+article > section > nav > a.m-presentation-cover {
+  text-align: center;
+  width: 2.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+article > section > nav > a.m-presentation-prev { text-align: right; }
+article > section > nav > a.m-presentation-prev::before { content: '«'; }
+article > section > nav > a.m-presentation-next { text-align: left; }
+article > section > nav > a.m-presentation-next::before { content: '»'; }
+article > section > aside.m-presenter {
+  display: none;
+}
+@media screen {
+  html:not(.m-presenter) article > section:first-child {
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    z-index: -1;
+    overflow: hidden;
+  }
+  article > section { display: none; }
+  article > section:target { display: block; }
+}
+html:not(.m-presenter) .m-container { width: 100%; }
+@media print { .m-container { width: 100%; } }
+@media print {
+  article > aside { display: none; }
+  article > section > nav { display: none; }
+  body { -webkit-print-color-adjust: exact; }
+  article > section:last-child { height: 99.99999vh; }
+  article > section:not(:first-of-type) { page-break-before: always; }
+  @page {
+    margin: 0;
+    size: 297mm 167mm;
+  }
+}
+@media screen {
+  html.m-presenter { font-size: 2.381vw; }
+  @media screen and (min-width: 576px) {
+    html.m-presenter { font-size: 13.3333px; }
+  }
+  @media screen and (min-width: 768px) {
+    html.m-presenter { font-size: 14.8809px; }
+  }
+  @media screen and (min-width: 992px) {
+    html.m-presenter { font-size: 19.0476px; }
+  }
+  html.m-presenter body {
+    overflow-y: scroll;
+  }
+  html.m-presenter article {
+    position: relative;
+    margin: 0;
+    padding-top: 56.25%;
+    background-color: #2f363f;
+  }
+  html.m-presenter article > aside,
+  html.m-presenter article > section {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+  }
+  html.m-presenter article > *:first-child {
+  }
+  html.m-presenter article > section > h1 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+    margin: 0;
+  }
+  html.m-presenter article > section > h1 + h2 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    margin: 0;
+  }
+  html.m-presenter article > aside > aside.m-presenter,
+  html.m-presenter article > section > aside.m-presenter {
+    display: block;
+    position: absolute;
+    top: 0;
+    margin-top: 56.25%;
+    color: #000000;
+    font-size: 16px;
+  }
+  html.m-presenter article > aside > aside.m-presenter {
+    padding-top: 1rem;
+  }
+  html.m-presenter article > section > aside.m-presenter {
+    padding-top: 3rem;
+  }
+  html.m-presenter article > section > aside.m-presenter code,
+  html.m-presenter article > section > aside.m-presenter pre {
+    color: #000000;
+    background-color: transparent;
+    font-size: 0.9em;
+  }
+}
+
+.m-code .hll { background-color: #34424d }
+.m-code .c { color: #a5c9ea }
+.m-code .k { color: #ffffff; font-weight: bold }
+.m-code .n { color: #dcdcdc }
+.m-code .o { color: #aaaaaa }
+.m-code .p { color: #aaaaaa }
+.m-code .ch { color: #a5c9ea }
+.m-code .cm { color: #a5c9ea }
+.m-code .cp { color: #3bd267 }
+.m-code .cpf { color: #c7cf2f }
+.m-code .c1 { color: #a5c9ea }
+.m-code .cs { color: #a5c9ea }
+.m-code .gd { color: #cd3431 }
+.m-code .ge { color: #e6e6e6; font-style: italic }
+.m-code .gh { color: #ffffff; font-weight: bold }
+.m-code .gi { color: #3bd267 }
+.m-code .gs { color: #e6e6e6; font-weight: bold }
+.m-code .gu { color: #5b9dd9 }
+.m-code .kc { color: #ffffff; font-weight: bold }
+.m-code .kd { color: #ffffff; font-weight: bold }
+.m-code .kn { color: #ffffff; font-weight: bold }
+.m-code .kp { color: #ffffff; font-weight: bold }
+.m-code .kr { color: #ffffff; font-weight: bold }
+.m-code .kt { color: #ffffff; font-weight: bold }
+.m-code .m { color: #c7cf2f }
+.m-code .s { color: #e07f7c }
+.m-code .na { color: #dcdcdc; font-weight: bold }
+.m-code .nb { color: #ffffff; font-weight: bold }
+.m-code .nc { color: #dcdcdc; font-weight: bold }
+.m-code .no { color: #dcdcdc }
+.m-code .nd { color: #dcdcdc }
+.m-code .ni { color: #dcdcdc }
+.m-code .ne { color: #dcdcdc }
+.m-code .nf { color: #dcdcdc }
+.m-code .nl { color: #dcdcdc }
+.m-code .nn { color: #dcdcdc }
+.m-code .nx { color: #dcdcdc }
+.m-code .py { color: #dcdcdc }
+.m-code .nt { color: #dcdcdc; font-weight: bold }
+.m-code .nv { color: #c7cf2f }
+.m-code .ow { color: #dcdcdc; font-weight: bold }
+.m-code .mb { color: #c7cf2f }
+.m-code .mf { color: #c7cf2f }
+.m-code .mh { color: #c7cf2f }
+.m-code .mi { color: #c7cf2f }
+.m-code .mo { color: #c7cf2f }
+.m-code .sa { color: #e07f7c }
+.m-code .sb { color: #e07f7c }
+.m-code .sc { color: #e07cdc }
+.m-code .dl { color: #e07f7c }
+.m-code .sd { color: #e07f7c }
+.m-code .s2 { color: #e07f7c }
+.m-code .se { color: #e07f7c }
+.m-code .sh { color: #e07f7c }
+.m-code .si { color: #e07f7c }
+.m-code .sx { color: #e07f7c }
+.m-code .sr { color: #e07f7c }
+.m-code .s1 { color: #e07f7c }
+.m-code .ss { color: #e07f7c }
+.m-code .bp { color: #ffffff; font-weight: bold }
+.m-code .fm { color: #dcdcdc }
+.m-code .vc { color: #c7cf2f }
+.m-code .vg { color: #c7cf2f }
+.m-code .vi { color: #c7cf2f }
+.m-code .vm { color: #c7cf2f }
+.m-code .il { color: #c7cf2f }
+
+.m-console .hll { background-color: #ffffcc }
+.m-console .g-AnsiBlack { color: #000000 }
+.m-console .g-AnsiBlue { color: #3f3fd1 }
+.m-console .g-AnsiBrightBlack { color: #686868; font-weight: bold }
+.m-console .g-AnsiBrightBlue { color: #5454ff; font-weight: bold }
+.m-console .g-AnsiBrightCyan { color: #54ffff; font-weight: bold }
+.m-console .g-AnsiBrightDefault { color: #ffffff; font-weight: bold }
+.m-console .g-AnsiBrightGreen { color: #54ff54; font-weight: bold }
+.m-console .g-AnsiBrightMagenta { color: #ff54ff; font-weight: bold }
+.m-console .g-AnsiBrightRed { color: #ff5454; font-weight: bold }
+.m-console .g-AnsiBrightWhite { color: #ffffff; font-weight: bold }
+.m-console .g-AnsiBrightYellow { color: #ffff54; font-weight: bold }
+.m-console .g-AnsiCyan { color: #18b2b2 }
+.m-console .g-AnsiDefault { color: #b2b2b2 }
+.m-console .g-AnsiGreen { color: #18b218 }
+.m-console .g-AnsiMagenta { color: #b218b2 }
+.m-console .g-AnsiRed { color: #b21818 }
+.m-console .g-AnsiWhite { color: #b2b2b2 }
+.m-console .g-AnsiYellow { color: #b26818 }
+.m-console .go { color: #b2b2b2 }
+.m-console .gp { color: #54ffff; font-weight: bold }
+.m-console .w { color: #b2b2b2 }

--- a/css/m-dark-presentation.css
+++ b/css/m-dark-presentation.css
@@ -1,0 +1,32 @@
+/*
+    This file is part of m.css.
+
+    Copyright © 2017, 2018 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+@import url('m-theme-dark.css');
+@import url('m-grid.css');
+@import url('m-components.css');
+@import url('m-presentation.css');
+@import url('pygments-dark.css');
+@import url('pygments-console.css');
+
+/* kate: indent-width 2; */

--- a/css/m-light-presentation.compiled.css
+++ b/css/m-light-presentation.compiled.css
@@ -1,0 +1,1998 @@
+/* Generated using `./postprocess.py m-light-presentation.css`. Do not edit. */
+
+/*
+    This file is part of m.css.
+
+    Copyright © 2017, 2018, 2019 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+*, ::before, ::after { box-sizing: border-box; }
+body { margin: 0; }
+.m-container {
+  width: 100%;
+  margin: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.m-row {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+.m-row:after {
+  content: ' ';
+  clear: both;
+  display: table;
+}
+.m-row > [class*='m-col-'] {
+  position: relative;
+  padding: 1rem;
+}
+[class*='m-clearfix-']::after {
+  display: block;
+  content: ' ';
+  clear: both;
+}
+[class*='m-show-'] {
+  display: none;
+}
+.m-container-inflate, :not(.m-row) > [class*='m-col-'] {
+  margin-bottom: 1rem;
+}
+.m-container-inflate:last-child, :not(.m-row) > [class*='m-col-']:last-child {
+  margin-bottom: 0;
+}
+.m-container.m-nopad, [class*='m-col-'].m-nopad,
+.m-container.m-nopadx, [class*='m-col-'].m-nopadx,
+.m-container.m-nopadl, [class*='m-col-'].m-nopadl {
+  padding-left: 0;
+}
+.m-container.m-nopad, [class*='m-col-'].m-nopad,
+.m-container.m-nopadx, [class*='m-col-'].m-nopadx,
+.m-container.m-nopadr, [class*='m-col-'].m-nopadr {
+  padding-right: 0;
+}
+[class*='m-col-'].m-nopad, [class*='m-col-'].m-nopady, [class*='m-col-'].m-nopadt {
+  padding-top: 0;
+}
+[class*='m-col-'].m-nopad, [class*='m-col-'].m-nopady, [class*='m-col-'].m-nopadb,
+.m-container-inflate.m-nopadb {
+  padding-bottom: 0;
+}
+[class*='m-col-t-'] { float: left; }
+.m-left-t {
+  padding-right: 1rem;
+  float: left;
+}
+.m-right-t, [class*='m-col-t-'].m-right-t {
+  padding-left: 1rem;
+  float: right;
+}
+.m-center-t, [class*='m-col-t-'].m-center-t {
+  float: none;
+}
+.m-center-t, [class*='m-col-t-'].m-center-t {
+  margin-left: auto;
+  margin-right: auto;
+  float: none;
+}
+.m-col-t-1  { width: calc(1  * 100% / 12); }
+.m-col-t-2  { width: calc(2  * 100% / 12); }
+.m-col-t-3  { width: calc(3  * 100% / 12); }
+.m-col-t-4  { width: calc(4  * 100% / 12); }
+.m-col-t-5  { width: calc(5  * 100% / 12); }
+.m-col-t-6  { width: calc(6  * 100% / 12); }
+.m-col-t-7  { width: calc(7  * 100% / 12); }
+.m-col-t-8  { width: calc(8  * 100% / 12); }
+.m-col-t-9  { width: calc(9  * 100% / 12); }
+.m-col-t-10 { width: calc(10 * 100% / 12); }
+.m-col-t-11 { width: calc(11 * 100% / 12); }
+.m-col-t-12 { width: calc(12 * 100% / 12); }
+.m-push-t-1  { left: calc(1  * 100% / 12); }
+.m-push-t-2  { left: calc(2  * 100% / 12); }
+.m-push-t-3  { left: calc(3  * 100% / 12); }
+.m-push-t-4  { left: calc(4  * 100% / 12); }
+.m-push-t-5  { left: calc(5  * 100% / 12); }
+.m-push-t-6  { left: calc(6  * 100% / 12); }
+.m-push-t-7  { left: calc(7  * 100% / 12); }
+.m-push-t-8  { left: calc(8  * 100% / 12); }
+.m-push-t-9  { left: calc(9  * 100% / 12); }
+.m-push-t-10 { left: calc(10 * 100% / 12); }
+.m-push-t-11 { left: calc(11 * 100% / 12); }
+.m-pull-t-1  { right: calc(1  * 100% / 12); }
+.m-pull-t-2  { right: calc(2  * 100% / 12); }
+.m-pull-t-3  { right: calc(3  * 100% / 12); }
+.m-pull-t-4  { right: calc(4  * 100% / 12); }
+.m-pull-t-5  { right: calc(5  * 100% / 12); }
+.m-pull-t-6  { right: calc(6  * 100% / 12); }
+.m-pull-t-7  { right: calc(7  * 100% / 12); }
+.m-pull-t-8  { right: calc(8  * 100% / 12); }
+.m-pull-t-9  { right: calc(9  * 100% / 12); }
+.m-pull-t-10 { right: calc(10 * 100% / 12); }
+.m-pull-t-11 { right: calc(11 * 100% / 12); }
+@media screen and (min-width: 576px) {
+  .m-container { width: 560px; }
+  .m-container-inflatable .m-col-s-10 .m-container-inflate:not([class*='m-left-']):not([class*='m-right-']) {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+  .m-container-inflatable .m-col-s-10 .m-container-inflate.m-left-s {
+    margin-left: -10%;
+  }
+  .m-container-inflatable .m-col-s-10 .m-container-inflate.m-right-s {
+    margin-right: -10%;
+  }
+  [class*='m-col-s-'] { float: left; }
+  .m-left-s {
+    padding-right: 1rem;
+    float: left;
+  }
+  .m-right-s, [class*='m-col-s-'].m-right-s {
+    padding-left: 1rem;
+    float: right;
+  }
+  .m-center-s, [class*='m-col-s-'].m-center-s {
+    margin-left: auto;
+    margin-right: auto;
+    float: none;
+  }
+  .m-col-s-1  { width: calc(1  * 100% / 12); }
+  .m-col-s-2  { width: calc(2  * 100% / 12); }
+  .m-col-s-3  { width: calc(3  * 100% / 12); }
+  .m-col-s-4  { width: calc(4  * 100% / 12); }
+  .m-col-s-5  { width: calc(5  * 100% / 12); }
+  .m-col-s-6  { width: calc(6  * 100% / 12); }
+  .m-col-s-7  { width: calc(7  * 100% / 12); }
+  .m-col-s-8  { width: calc(8  * 100% / 12); }
+  .m-col-s-9  { width: calc(9  * 100% / 12); }
+  .m-col-s-10 { width: calc(10 * 100% / 12); }
+  .m-col-s-11 { width: calc(11 * 100% / 12); }
+  .m-col-s-12 { width: calc(12 * 100% / 12); }
+  .m-push-s-0  { left: calc(0  * 100% / 12); }
+  .m-push-s-1  { left: calc(1  * 100% / 12); }
+  .m-push-s-2  { left: calc(2  * 100% / 12); }
+  .m-push-s-3  { left: calc(3  * 100% / 12); }
+  .m-push-s-4  { left: calc(4  * 100% / 12); }
+  .m-push-s-5  { left: calc(5  * 100% / 12); }
+  .m-push-s-6  { left: calc(6  * 100% / 12); }
+  .m-push-s-7  { left: calc(7  * 100% / 12); }
+  .m-push-s-8  { left: calc(8  * 100% / 12); }
+  .m-push-s-9  { left: calc(9  * 100% / 12); }
+  .m-push-s-10 { left: calc(10 * 100% / 12); }
+  .m-push-s-11 { left: calc(11 * 100% / 12); }
+  .m-pull-s-0  { right: calc(0  * 100% / 12); }
+  .m-pull-s-1  { right: calc(1  * 100% / 12); }
+  .m-pull-s-2  { right: calc(2  * 100% / 12); }
+  .m-pull-s-3  { right: calc(3  * 100% / 12); }
+  .m-pull-s-4  { right: calc(4  * 100% / 12); }
+  .m-pull-s-5  { right: calc(5  * 100% / 12); }
+  .m-pull-s-6  { right: calc(6  * 100% / 12); }
+  .m-pull-s-7  { right: calc(7  * 100% / 12); }
+  .m-pull-s-8  { right: calc(8  * 100% / 12); }
+  .m-pull-s-9  { right: calc(9  * 100% / 12); }
+  .m-pull-s-10 { right: calc(10 * 100% / 12); }
+  .m-pull-s-11 { right: calc(11 * 100% / 12); }
+  .m-clearfix-t::after { display: none; }
+  .m-hide-s { display: none; }
+  .m-show-s { display: block; }
+  .m-col-s-none {
+    width: auto;
+    float: none;
+  }
+}
+@media screen and (min-width: 768px) {
+  .m-container { width: 750px; }
+  .m-container-inflatable .m-col-m-10 .m-container-inflate:not([class*='m-left-']):not([class*='m-right-']) {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+  .m-container-inflatable .m-col-m-10 .m-container-inflate.m-left-m {
+    margin-left: -10%;
+  }
+  .m-container-inflatable .m-col-m-10 .m-container-inflate.m-right-m {
+    margin-right: -10%;
+  }
+  [class*='m-col-m-'] { float: left; }
+  .m-left-m {
+    padding-right: 1rem;
+    float: left;
+  }
+  .m-right-m, [class*='m-col-m-'].m-right-m {
+    padding-left: 1rem;
+    float: right;
+  }
+  .m-center-m, [class*='m-col-m-'].m-center-m {
+    margin-left: auto;
+    margin-right: auto;
+    float: none;
+  }
+  .m-col-m-1  { width: calc(1  * 100% / 12); }
+  .m-col-m-2  { width: calc(2  * 100% / 12); }
+  .m-col-m-3  { width: calc(3  * 100% / 12); }
+  .m-col-m-4  { width: calc(4  * 100% / 12); }
+  .m-col-m-5  { width: calc(5  * 100% / 12); }
+  .m-col-m-6  { width: calc(6  * 100% / 12); }
+  .m-col-m-7  { width: calc(7  * 100% / 12); }
+  .m-col-m-8  { width: calc(8  * 100% / 12); }
+  .m-col-m-9  { width: calc(9  * 100% / 12); }
+  .m-col-m-10 { width: calc(10 * 100% / 12); }
+  .m-col-m-11 { width: calc(11 * 100% / 12); }
+  .m-col-m-12 { width: calc(12 * 100% / 12); }
+  .m-push-m-0  { left: calc(0  * 100% / 12); }
+  .m-push-m-1  { left: calc(1  * 100% / 12); }
+  .m-push-m-2  { left: calc(2  * 100% / 12); }
+  .m-push-m-3  { left: calc(3  * 100% / 12); }
+  .m-push-m-4  { left: calc(4  * 100% / 12); }
+  .m-push-m-5  { left: calc(5  * 100% / 12); }
+  .m-push-m-6  { left: calc(6  * 100% / 12); }
+  .m-push-m-7  { left: calc(7  * 100% / 12); }
+  .m-push-m-8  { left: calc(8  * 100% / 12); }
+  .m-push-m-9  { left: calc(9  * 100% / 12); }
+  .m-push-m-10 { left: calc(10 * 100% / 12); }
+  .m-push-m-11 { left: calc(11 * 100% / 12); }
+  .m-pull-m-0  { right: calc(0  * 100% / 12); }
+  .m-pull-m-1  { right: calc(1  * 100% / 12); }
+  .m-pull-m-2  { right: calc(2  * 100% / 12); }
+  .m-pull-m-3  { right: calc(3  * 100% / 12); }
+  .m-pull-m-4  { right: calc(4  * 100% / 12); }
+  .m-pull-m-5  { right: calc(5  * 100% / 12); }
+  .m-pull-m-6  { right: calc(6  * 100% / 12); }
+  .m-pull-m-7  { right: calc(7  * 100% / 12); }
+  .m-pull-m-8  { right: calc(8  * 100% / 12); }
+  .m-pull-m-9  { right: calc(9  * 100% / 12); }
+  .m-pull-m-10 { right: calc(10 * 100% / 12); }
+  .m-pull-m-11 { right: calc(11 * 100% / 12); }
+  .m-clearfix-s::after { display: none; }
+  .m-hide-m { display: none; }
+  .m-show-m { display: block; }
+  .m-col-m-none {
+    width: auto;
+    float: none;
+  }
+}
+@media screen and (min-width: 992px) {
+  .m-container { width: 960px; }
+  .m-container-inflatable .m-col-l-10 .m-container-inflate:not([class*='m-left-']):not([class*='m-right-']) {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+  .m-container-inflatable .m-col-l-10 .m-container-inflate.m-left-l {
+    margin-left: -10%;
+  }
+  .m-container-inflatable .m-col-l-10 .m-container-inflate.m-right-l {
+    margin-right: -10%;
+  }
+  [class*='m-col-l-'] { float: left; }
+  .m-left-l {
+    padding-right: 1rem;
+    float: left;
+  }
+  .m-right-l, [class*='m-col-l-'].m-right-l {
+    padding-left: 1rem;
+    float: right;
+  }
+  .m-center-l, [class*='m-col-l-'].m-center-l {
+    margin-left: auto;
+    margin-right: auto;
+    float: none;
+  }
+  .m-col-l-1  { width: calc(1  * 100% / 12); }
+  .m-col-l-2  { width: calc(2  * 100% / 12); }
+  .m-col-l-3  { width: calc(3  * 100% / 12); }
+  .m-col-l-4  { width: calc(4  * 100% / 12); }
+  .m-col-l-5  { width: calc(5  * 100% / 12); }
+  .m-col-l-6  { width: calc(6  * 100% / 12); }
+  .m-col-l-7  { width: calc(7  * 100% / 12); }
+  .m-col-l-8  { width: calc(8  * 100% / 12); }
+  .m-col-l-9  { width: calc(9  * 100% / 12); }
+  .m-col-l-10 { width: calc(10 * 100% / 12); }
+  .m-col-l-11 { width: calc(11 * 100% / 12); }
+  .m-col-l-12 { width: calc(12 * 100% / 12); }
+  .m-push-l-0  { left: calc(0  * 100% / 12); }
+  .m-push-l-1  { left: calc(1  * 100% / 12); }
+  .m-push-l-2  { left: calc(2  * 100% / 12); }
+  .m-push-l-3  { left: calc(3  * 100% / 12); }
+  .m-push-l-4  { left: calc(4  * 100% / 12); }
+  .m-push-l-5  { left: calc(5  * 100% / 12); }
+  .m-push-l-6  { left: calc(6  * 100% / 12); }
+  .m-push-l-7  { left: calc(7  * 100% / 12); }
+  .m-push-l-8  { left: calc(8  * 100% / 12); }
+  .m-push-l-9  { left: calc(9  * 100% / 12); }
+  .m-push-l-10 { left: calc(10 * 100% / 12); }
+  .m-push-l-11 { left: calc(11 * 100% / 12); }
+  .m-pull-l-0  { right: calc(0  * 100% / 12); }
+  .m-pull-l-1  { right: calc(1  * 100% / 12); }
+  .m-pull-l-2  { right: calc(2  * 100% / 12); }
+  .m-pull-l-3  { right: calc(3  * 100% / 12); }
+  .m-pull-l-4  { right: calc(4  * 100% / 12); }
+  .m-pull-l-5  { right: calc(5  * 100% / 12); }
+  .m-pull-l-6  { right: calc(6  * 100% / 12); }
+  .m-pull-l-7  { right: calc(7  * 100% / 12); }
+  .m-pull-l-8  { right: calc(8  * 100% / 12); }
+  .m-pull-l-9  { right: calc(9  * 100% / 12); }
+  .m-pull-l-10 { right: calc(10 * 100% / 12); }
+  .m-pull-l-11 { right: calc(11 * 100% / 12); }
+  .m-clearfix-m::after { display: none; }
+  .m-hide-l { display: none; }
+  .m-show-l { display: block; }
+  .m-col-l-none {
+    width: auto;
+    float: none;
+  }
+}
+
+html {
+  font-size: 14px;
+  background-color: #ffffff;
+}
+body {
+  font-family: 'Libre Baskerville', serif;
+  font-size: 1rem;
+  color: #000000;
+}
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0;
+  font-weight: normal;
+}
+h1 {
+  margin-bottom: 1rem;
+}
+h2, h3, h4, h5, h6 {
+  margin-bottom: 0.5rem;
+}
+p, ul, ol, dl {
+  margin-top: 0;
+}
+ul, ol {
+  padding-left: 2rem;
+}
+ul ol, ul ul, ol ol, ol ul {
+  margin-bottom: 0;
+}
+main p {
+  text-indent: 1.5rem;
+  text-align: justify;
+}
+main p.m-noindent, li > p, dd > p, table.m-table td > p {
+  text-indent: 0;
+  text-align: left;
+}
+blockquote {
+  margin-top: 0;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  padding: 1rem;
+  border-left-style: solid;
+  border-left-width: 0.25rem;
+}
+hr {
+  width: 75%;
+  border-width: 0.0625rem;
+  border-style: solid;
+}
+blockquote, hr {
+  border-color: #f7e3db;
+}
+pre {
+  font-family: 'Source Code Pro', monospace, monospace, monospace;
+  font-size: 1em;
+  padding: 0.5rem 1rem;
+  color: #5b5b5b;
+  background-color: #fbf0ec;
+  border-radius: 0.2rem;
+  overflow-x: auto;
+  margin-top: 0;
+}
+pre.m-console-wrap {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+pre.m-console {
+  background-color: #000000;
+}
+strong, .m-text.m-strong { font-weight: bold; }
+em, .m-text.m-em { font-style: italic; }
+s, .m-text.m-s { text-decoration: line-through; }
+sub, sup, .m-text.m-sub, .m-text.m-sup {
+  font-size: 0.75rem;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sup, .m-text.m-sup { top: -0.35rem; }
+sub, .m-text.m-sub { bottom: -0.2rem; }
+abbr {
+  cursor: help;
+  text-decoration: underline dotted;
+}
+a {
+  color: #ea7944;
+}
+a.m-flat {
+  text-decoration: none;
+}
+a:hover, a:focus, a:active {
+  color: #cb4b16;
+}
+a img { border: 0; }
+svg a { cursor: pointer; }
+mark {
+  padding: 0.0625rem;
+  background-color: #e6e69c;
+  color: #4c93d3;
+}
+code {
+  font-family: 'Source Code Pro', monospace, monospace, monospace;
+  font-size: 1em;
+  padding: 0.125rem;
+  color: #5b5b5b;
+  background-color: #fbf0ec;
+}
+code.m-console {
+  background-color: #000000;
+}
+*:focus { outline-color: #ea7944; }
+div.m-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+}
+.m-fullwidth {
+  width: 100%;
+}
+.m-spacing-150 {
+  line-height: 1.5rem;
+}
+.m-text-center, .m-text-center.m-noindent, table.m-table th.m-text-center, .m-text-center p {
+  text-align: center;
+}
+.m-text-left, .m-text-left.m-noindent, table.m-table th.m-text-left, .m-text-right p {
+  text-align: left;
+}
+.m-text-right, .m-text-right.m-noindent, table.m-table th.m-text-right, .m-text-right p {
+  text-align: right;
+}
+.m-text-top, table.m-table th.m-text-top, table.m-table td.m-text-top {
+  vertical-align: top;
+}
+.m-text-middle, table.m-table th.m-text-middle, table.m-table td.m-text-middle {
+  vertical-align: middle;
+}
+.m-text-bottom, table.m-table th.m-text-bottom, table.m-table td.m-text-bottom {
+  vertical-align: bottom;
+}
+.m-text.m-tiny { font-size: 50.0%; }
+.m-text.m-small { font-size: 85.4%; }
+.m-text.m-big { font-size: 117%; }
+h1 .m-thin, h2 .m-thin, h3 .m-thin, h4 .m-thin, h5 .m-thin, h6 .m-thin {
+  font-weight: normal;
+}
+ul.m-unstyled, ol.m-unstyled {
+  list-style-type: none;
+  padding-left: 0;
+}
+ul[class*='m-block-'], ol[class*='m-block-'] {
+  padding-left: 0;
+}
+ul[class*='m-block-'] li, ol[class*='m-block-'] li {
+  display: inline;
+}
+ul[class*='m-block-bar-'] li:not(:last-child)::after, ol[class*='m-block-bar-'] li:not(:last-child)::after {
+  content: " | ";
+}
+ul[class*='m-block-dot-'] li:not(:last-child)::after, ol[class*='m-block-dot-'] li:not(:last-child)::after {
+  content: " • ";
+}
+@media screen and (min-width: 576px) {
+  ul.m-block-bar-s, ol.m-block-bar-s,
+  ul.m-block-dot-s, ol.m-block-dot-s { padding-left: 2rem; }
+  ul.m-block-bar-s li, ol.m-block-bar-s li,
+  ul.m-block-dot-s li, ol.m-block-dot-s li { display: list-item; }
+  ul.m-block-bar-s li:not(:last-child)::after, ol.m-block-bar-s li:not(:last-child)::after,
+  ul.m-block-dot-s li:not(:last-child)::after, ol.m-block-dot-s li:not(:last-child)::after { content: ""; }
+}
+@media screen and (min-width: 768px) {
+  ul.m-block-bar-m, ol.m-block-bar-m,
+  ul.m-block-dot-m, ol.m-block-dot-m { padding-left: 2rem; }
+  ul.m-block-bar-m li, ol.m-block-bar-m li,
+  ul.m-block-dot-m li, ol.m-block-dot-m li { display: list-item; }
+  ul.m-block-bar-m li:not(:last-child)::after, ol.m-block-bar-m li:not(:last-child)::after,
+  ul.m-block-dot-m li:not(:last-child)::after, ol.m-block-dot-m li:not(:last-child)::after { content: ""; }
+}
+@media screen and (min-width: 992px) {
+  ul.m-block-bar-l, ol.m-block-bar-l,
+  ul.m-block-dot-l, ol.m-block-dot-l { padding-left: 2rem; }
+  ul.m-block-bar-l li, ol.m-block-bar-l li,
+  ul.m-block-dot-l li, ol.m-block-dot-l li { display: list-item; }
+  ul.m-block-bar-l li:not(:last-child)::after, ol.m-block-bar-l li:not(:last-child)::after,
+  ul.m-block-dot-l li:not(:last-child)::after, ol.m-block-dot-l li:not(:last-child)::after { content: ""; }
+}
+p.m-poem {
+  text-indent: 0;
+  text-align: left;
+  margin-left: 1.5rem;
+}
+p.m-transition {
+  color: #f7e3db;
+  text-indent: 0;
+  text-align: center;
+  font-size: 2rem;
+}
+dl.m-diary {
+  margin-bottom: 1.25rem;
+}
+dl.m-diary:last-child {
+  margin-bottom: 0.25rem;
+}
+dl.m-diary dt {
+  font-weight: bold;
+  width: 3.5rem;
+  float: left;
+  clear: both;
+  padding-top: 0.25rem;
+}
+dl.m-diary dd {
+  padding-top: 0.25rem;
+  padding-left: 3.5rem;
+}
+a.m-footnote, dl.m-footnote dd span.m-footnote {
+  top: -0.35rem;
+  font-size: 0.75rem;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+a.m-footnote, dl.m-footnote dd span.m-footnote a {
+  text-decoration: none;
+}
+a.m-footnote::before { content: '['; }
+a.m-footnote::after { content: ']'; }
+dl.m-footnote dt {
+  width: 1.5rem;
+  float: left;
+  clear: both;
+}
+dl.m-footnote dd {
+  margin-left: 1.5rem;
+}
+dl.m-footnote {
+  font-size: 85.4%;
+}
+dl.m-footnote dd span.m-footnote a {
+  font-weight: bold;
+  font-style: italic;
+}
+.m-note {
+  border-radius: 0.2rem;
+  padding: 1rem;
+}
+.m-frame {
+  background-color: #ffffff;
+  border-style: solid;
+  border-width: 0.125rem;
+  border-radius: 0.2rem;
+  border-color: #f7e3db;
+  padding: 0.875rem;
+}
+.m-block {
+  border-style: solid;
+  border-width: 0.0625rem;
+  border-left-width: 0.25rem;
+  border-radius: 0.2rem;
+  border-color: #f7e3db;
+  padding: 0.9375rem 0.9375rem 0.9375rem 0.75rem;
+}
+.m-block.m-badge::after {
+  content: ' ';
+  display: block;
+  clear: both;
+}
+.m-block.m-badge h3 {
+  margin-left: 5rem;
+}
+.m-block.m-badge p {
+  margin-left: 5rem;
+  text-indent: 0;
+}
+.m-block.m-badge img {
+  width: 4rem;
+  height: 4rem;
+  border-radius: 2rem;
+  float: left;
+}
+div.m-button {
+  text-align: center;
+}
+div.m-button a {
+  display: inline-block;
+  border-radius: 0.2rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  text-decoration: none;
+  font-size: 1.17rem;
+}
+div.m-button.m-fullwidth a {
+  display: block;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+div.m-button a .m-big:first-child {
+  font-size: 1.37rem;
+  font-weight: bold;
+}
+div.m-button a .m-small:last-child {
+  font-size: 0.854rem;
+}
+.m-label {
+  border-radius: 0.2rem;
+  font-size: 75%;
+  font-weight: normal;
+  padding: 0.125rem 0.25rem;
+  vertical-align: 7.5%;
+}
+.m-label.m-flat {
+  border-width: 0.0625rem;
+  border-style: solid;
+  border-color: #bdbdbd;
+  padding: 0.0625rem 0.1875rem;
+}
+table.m-table {
+  border-collapse: collapse;
+  margin-left: auto;
+  margin-right: auto;
+}
+table.m-table.m-big {
+  margin-top: 1.75rem;
+}
+div.m-scroll > table.m-table:last-child {
+  margin-bottom: 0.0625rem;
+}
+table.m-table:not(.m-flat) tbody tr:hover {
+  background-color: #f7e3db;
+}
+table.m-table th, table.m-table td {
+  vertical-align: top;
+  border-style: solid;
+  border-top-width: 0.0625rem;
+  border-left-width: 0;
+  border-right-width: 0;
+  border-bottom-width: 0;
+  border-color: #f7e3db;
+}
+table.m-table caption {
+  padding-bottom: 0.5rem;
+}
+table.m-table thead tr:first-child th, table.m-table thead tr:first-child td {
+  border-top-width: 0.125rem;
+}
+table.m-table thead th, table.m-table thead td {
+  border-bottom-width: 0.125rem;
+  vertical-align: bottom;
+}
+table.m-table tfoot th, table.m-table tfoot td {
+  border-top-width: 0.125rem;
+}
+table.m-table th, table.m-table td {
+  padding: 0.5rem;
+}
+table.m-table.m-big th, table.m-table.m-big td {
+  padding: 0.75rem 1rem;
+}
+table.m-table th {
+  text-align: left;
+}
+table.m-table th.m-thin {
+  font-weight: normal;
+}
+table.m-table td.m-default, table.m-table th.m-default,
+table.m-table td.m-primary, table.m-table th.m-primary,
+table.m-table td.m-success, table.m-table th.m-success,
+table.m-table td.m-warning, table.m-table th.m-warning,
+table.m-table td.m-danger, table.m-table th.m-danger,
+table.m-table td.m-info, table.m-table th.m-info,
+table.m-table td.m-dim, table.m-table th.m-dim {
+  padding-left: 0.4375rem;
+  padding-right: 0.4375rem;
+  border-left-width: 0.0625rem;
+}
+table.m-table.m-big td.m-default, table.m-table.m-big th.m-default,
+table.m-table.m-big td.m-primary, table.m-table.m-big th.m-primary,
+table.m-table.m-big td.m-success, table.m-table.m-big th.m-success,
+table.m-table.m-big td.m-warning, table.m-table.m-big th.m-warning,
+table.m-table.m-big td.m-danger, table.m-table.m-big th.m-danger,
+table.m-table.m-big td.m-info, table.m-table.m-big th.m-info,
+table.m-table.m-big td.m-dim, table.m-table.m-big th.m-dim {
+  padding-left: 0.9375rem;
+  padding-right: 0.9375rem;
+  border-left-width: 0.0625rem;
+}
+table.m-table tr.m-default td, table.m-table td.m-default,
+table.m-table tr.m-default th, table.m-table th.m-default,
+table.m-table tr.m-primary td, table.m-table td.m-primary,
+table.m-table tr.m-primary th, table.m-table th.m-primary,
+table.m-table tr.m-success td, table.m-table td.m-success,
+table.m-table tr.m-success th, table.m-table th.m-success,
+table.m-table tr.m-warning td, table.m-table td.m-warning,
+table.m-table tr.m-warning th, table.m-table th.m-warning,
+table.m-table tr.m-danger td, table.m-table td.m-danger,
+table.m-table tr.m-danger th, table.m-table th.m-danger,
+table.m-table tr.m-info td, table.m-table td.m-info,
+table.m-table tr.m-info th, table.m-table th.m-info,
+table.m-table tr.m-dim td, table.m-table td.m-dim,
+table.m-table tr.m-dim th, table.m-table th.m-dim {
+  border-color: #ffffff;
+}
+.m-note pre, .m-note code,
+table.m-table tr.m-default pre, table.m-table tr.m-default code,
+table.m-table td.m-default pre, table.m-table td.m-default code,
+table.m-table th.m-default pre, table.m-table th.m-default code,
+table.m-table tr.m-primary pre, table.m-table tr.m-primary code,
+table.m-table td.m-primary pre, table.m-table td.m-primary code,
+table.m-table th.m-primary pre, table.m-table th.m-primary code,
+table.m-table tr.m-success pre, table.m-table tr.m-success code,
+table.m-table td.m-success pre, table.m-table td.m-success code,
+table.m-table th.m-success pre, table.m-table th.m-success code,
+table.m-table tr.m-warning pre, table.m-table tr.m-warning code,
+table.m-table td.m-warning pre, table.m-table td.m-warning code,
+table.m-table th.m-warning pre, table.m-table th.m-warning code,
+table.m-table tr.m-danger pre, table.m-table tr.m-danger code,
+table.m-table td.m-danger pre, table.m-table td.m-danger code,
+table.m-table th.m-danger pre, table.m-table th.m-danger code,
+table.m-table tr.m-info pre, table.m-table tr.m-info code,
+table.m-table td.m-info pre, table.m-table td.m-info code,
+table.m-table th.m-info pre, table.m-table th.m-info code,
+table.m-table tr.m-dim pre, table.m-table tr.m-dim code,
+table.m-table td.m-dim pre, table.m-table td.m-dim code,
+table.m-table th.m-dim pre, table.m-table th.m-dim code {
+  background-color: rgba(251, 240, 236, 0.5);
+}
+img.m-image, svg.m-image {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+div.m-image {
+  text-align: center;
+}
+img.m-image, svg.m-image, div.m-image img, div.m-image svg {
+  max-width: 100%;
+  border-radius: 0.2rem;
+}
+div.m-image.m-fullwidth img, div.m-image.m-fullwidth svg {
+  width: 100%;
+}
+figure.m-figure {
+  max-width: 100%;
+  margin-top: 0;
+  margin-left: auto;
+  margin-right: auto;
+  position: relative;
+  display: table;
+}
+figure.m-figure:before {
+  position: absolute;
+  content: ' ';
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: -1;
+  border-style: solid;
+  border-width: 0.125rem;
+  border-radius: 0.2rem;
+  border-color: #f7e3db;
+}
+figure.m-figure.m-flat:before {
+  border-color: transparent;
+}
+figure.m-figure > * {
+  margin-left: 1rem;
+  margin-right: 1rem;
+  display: table-caption;
+  caption-side: bottom;
+}
+figure.m-figure > *:first-child {
+  display: inline;
+}
+figure.m-figure > *:last-child {
+  margin-bottom: 1rem !important;
+}
+figure.m-figure img, figure.m-figure svg {
+  position: relative;
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  border-top-left-radius: 0.2rem;
+  border-top-right-radius: 0.2rem;
+  max-width: 100%;
+}
+figure.m-figure.m-flat img, figure.m-figure.m-flat svg {
+  border-bottom-left-radius: 0.2rem;
+  border-bottom-right-radius: 0.2rem;
+}
+figure.m-figure a img, figure.m-figure a svg {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+figure.m-figure.m-fullwidth, figure.m-figure.m-fullwidth > * {
+  display: block;
+}
+figure.m-figure.m-fullwidth > *:first-child {
+  display: inline;
+}
+figure.m-figure.m-fullwidth img, figure.m-figure.m-fullwidth svg {
+  width: 100%;
+}
+figure.m-figure.m-fullwidth:after {
+  content: ' ';
+  display: block;
+  margin-top: 1rem;
+  height: 1px;
+}
+.m-code-figure, .m-console-figure {
+  margin-top: 0;
+  margin-left: 0;
+  margin-right: 0;
+  position: relative;
+  padding: 1rem;
+}
+.m-code-figure:before, .m-console-figure:before {
+  position: absolute;
+  content: ' ';
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: -1;
+  border-style: solid;
+  border-width: 0.125rem;
+  border-radius: 0.2rem;
+}
+.m-code-figure:before {
+  border-color: #fbf0ec;
+}
+.m-console-figure:before {
+  border-color: #000000;
+}
+.m-code-figure.m-flat:before, .m-console-figure.m-flat:before {
+  border-color: transparent;
+}
+.m-code-figure > pre:first-child, .m-console-figure > pre:first-child {
+  position: relative;
+  margin: -1rem -1rem 1rem -1rem;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.m-code-figure > pre.m-nopad, .m-console-figure > pre.m-nopad {
+  margin-left: -0.875rem;
+  margin-right: -0.875rem;
+  margin-top: -1rem;
+  margin-bottom: -0.875rem;
+  padding-left: 0.875rem;
+}
+figure.m-figure figcaption, .m-code-figure figcaption, .m-console-figure figcaption {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: normal;
+  font-size: 1.17rem;
+}
+.m-imagegrid > div {
+  background-color: #ffffff;
+}
+.m-imagegrid > div > figure {
+  display: block;
+  float: left;
+  position: relative;
+  margin: 0;
+}
+.m-imagegrid > div > figure > div,
+.m-imagegrid > div > figure > figcaption,
+.m-imagegrid > div > figure > a > div,
+.m-imagegrid > div > figure > a > figcaption {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-color: #ffffff;
+  border-style: solid;
+  border-width: 0.25rem;
+  padding: 0.5rem;
+}
+.m-imagegrid > div > figure:first-child > div,
+.m-imagegrid > div > figure:first-child > figcaption,
+.m-imagegrid > div > figure:first-child > a > div,
+.m-imagegrid > div > figure:first-child > a > figcaption {
+  border-left-width: 0;
+}
+.m-imagegrid > div > figure:last-child > div,
+.m-imagegrid > div > figure:last-child > figcaption,
+.m-imagegrid > div > figure:last-child > a > div,
+.m-imagegrid > div > figure:last-child > a > figcaption {
+  border-right-width: 0;
+}
+.m-imagegrid > div > figure > figcaption,
+.m-imagegrid > div > figure > a > figcaption {
+  color: transparent;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.75rem;
+}
+.m-imagegrid > div > figure > div::before,
+.m-imagegrid > div > figure > figcaption::before,
+.m-imagegrid > div > figure > a > div::before,
+.m-imagegrid > div > figure > a > figcaption::before {
+  content: '';
+  display: inline-block;
+  height: 100%;
+  vertical-align: bottom;
+  width: 0;
+}
+.m-imagegrid > div > figure:hover > figcaption,
+.m-imagegrid > div > figure:hover > a > figcaption {
+  background: linear-gradient(transparent 0%, transparent 75%, rgba(0, 0, 0, 0.85) 100%);
+  color: #ffffff;
+}
+.m-imagegrid > div > figure > img,
+.m-imagegrid > div > figure > a > img {
+  width: 100%;
+  height: 100%;
+}
+.m-imagegrid > div::after {
+  display: block;
+  content: ' ';
+  clear: both;
+}
+@media screen and (max-width: 767px) {
+  .m-imagegrid > div > figure {
+    float: none;
+    width: 100% !important;
+  }
+  .m-imagegrid > div > figure > div,
+  .m-imagegrid > div > figure > figcaption,
+  .m-imagegrid > div > figure > a > div,
+  .m-imagegrid > div > figure > a > figcaption {
+    border-left-width: 0;
+    border-right-width: 0;
+  }
+}
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-note,
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-frame,
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-block,
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-imagegrid,
+.m-container-inflatable > .m-row > [class*='m-col-'] > pre,
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-code-figure,
+.m-container-inflatable > .m-row > [class*='m-col-'] > .m-console-figure,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-note,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-frame,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-block,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-imagegrid,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > pre,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-code-figure,
+.m-container-inflatable > .m-row > [class*='m-col-'] section > .m-console-figure,
+.m-container-inflatable [class*='m-center-'] > .m-note,
+.m-container-inflatable [class*='m-center-'] > .m-frame,
+.m-container-inflatable [class*='m-center-'] > .m-block,
+.m-container-inflatable [class*='m-center-'] > .m-imagegrid,
+.m-container-inflatable [class*='m-center-'] > pre,
+.m-container-inflatable [class*='m-center-'] > .m-code-figure,
+.m-container-inflatable [class*='m-center-'] > .m-console-figure,
+.m-container-inflatable [class*='m-left-'] > .m-note,
+.m-container-inflatable [class*='m-left-'] > .m-frame,
+.m-container-inflatable [class*='m-left-'] > .m-block,
+.m-container-inflatable [class*='m-left-'] > .m-imagegrid,
+.m-container-inflatable [class*='m-left-'] > pre,
+.m-container-inflatable [class*='m-left-'] > .m-code-figure,
+.m-container-inflatable [class*='m-left-'] > .m-console-figure,
+.m-container-inflatable [class*='m-right-'] > .m-note,
+.m-container-inflatable [class*='m-right-'] > .m-frame,
+.m-container-inflatable [class*='m-right-'] > .m-block,
+.m-container-inflatable [class*='m-right-'] > .m-imagegrid,
+.m-container-inflatable [class*='m-right-'] > pre,
+.m-container-inflatable [class*='m-right-'] > .m-code-figure,
+.m-container-inflatable [class*='m-right-'] > .m-console-figure,
+.m-container-inflatable .m-container-inflate > .m-note,
+.m-container-inflatable .m-container-inflate > .m-frame,
+.m-container-inflatable .m-container-inflate > .m-block,
+.m-container-inflatable .m-container-inflate > .m-imagegrid,
+.m-container-inflatable .m-container-inflate > pre,
+.m-container-inflatable .m-container-inflate > .m-code-figure,
+.m-container-inflatable .m-container-inflate > .m-console-figure
+{
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+@media screen and (min-width: 576px) {
+  .m-container-inflatable .m-center-s > .m-note,
+  .m-container-inflatable .m-center-s > .m-frame,
+  .m-container-inflatable .m-center-s > .m-block,
+  .m-container-inflatable .m-center-s > .m-imagegrid,
+  .m-container-inflatable .m-center-s > pre,
+  .m-container-inflatable .m-center-s > .m-code-figure,
+  .m-container-inflatable .m-center-s > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable .m-left-s > .m-note,
+  .m-container-inflatable .m-left-s > .m-frame,
+  .m-container-inflatable .m-left-s > .m-block,
+  .m-container-inflatable .m-left-s > .m-imagegrid,
+  .m-container-inflatable .m-left-s > pre,
+  .m-container-inflatable .m-left-s > .m-code-figure,
+  .m-container-inflatable .m-left-s > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: 0;
+  }
+  .m-container-inflatable .m-right-s > .m-note,
+  .m-container-inflatable .m-right-s > .m-frame,
+  .m-container-inflatable .m-right-s > .m-block,
+  .m-container-inflatable .m-right-s > .m-imagegrid,
+  .m-container-inflatable .m-right-s > pre,
+  .m-container-inflatable .m-right-s > .m-code-figure,
+  .m-container-inflatable .m-right-s > .m-console-figure {
+    margin-left: 0;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable > .m-row > .m-col-s-10 > .m-imagegrid.m-container-inflate,
+  .m-container-inflatable > .m-row > .m-col-s-10 section > .m-imagegrid.m-container-inflate {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+}
+@media screen and (min-width: 768px) {
+  .m-container-inflatable .m-center-m > .m-note,
+  .m-container-inflatable .m-center-m > .m-frame,
+  .m-container-inflatable .m-center-m > .m-block,
+  .m-container-inflatable .m-center-m > .m-imagegrid,
+  .m-container-inflatable .m-center-m > pre,
+  .m-container-inflatable .m-center-m > .m-code-figure,
+  .m-container-inflatable .m-center-m > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable .m-left-m > .m-note,
+  .m-container-inflatable .m-left-m > .m-frame,
+  .m-container-inflatable .m-left-m > .m-block,
+  .m-container-inflatable .m-left-m > .m-imagegrid,
+  .m-container-inflatable .m-left-m > pre,
+  .m-container-inflatable .m-left-m > .m-code-figure,
+  .m-container-inflatable .m-left-m > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: 0;
+  }
+  .m-container-inflatable .m-right-m > .m-note,
+  .m-container-inflatable .m-right-m > .m-frame,
+  .m-container-inflatable .m-right-m > .m-block,
+  .m-container-inflatable .m-right-m > .m-imagegrid,
+  .m-container-inflatable .m-right-m > pre,
+  .m-container-inflatable .m-right-m > .m-code-figure,
+  .m-container-inflatable .m-right-m > .m-console-figure {
+    margin-left: 0;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable > .m-row > .m-col-m-10 > .m-imagegrid.m-container-inflate,
+  .m-container-inflatable > .m-row > .m-col-m-10 section > .m-imagegrid.m-container-inflate {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+}
+@media screen and (min-width: 992px) {
+  .m-container-inflatable .m-center-l > .m-note,
+  .m-container-inflatable .m-center-l > .m-frame,
+  .m-container-inflatable .m-center-l > .m-block,
+  .m-container-inflatable .m-center-l > .m-imagegrid,
+  .m-container-inflatable .m-center-l > pre,
+  .m-container-inflatable .m-center-l > .m-code-figure,
+  .m-container-inflatable .m-center-l > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable .m-left-l > .m-note,
+  .m-container-inflatable .m-left-l > .m-frame,
+  .m-container-inflatable .m-left-l > .m-block,
+  .m-container-inflatable .m-left-l > .m-imagegrid,
+  .m-container-inflatable .m-left-l > pre,
+  .m-container-inflatable .m-left-l > .m-code-figure,
+  .m-container-inflatable .m-left-l > .m-console-figure {
+    margin-left: -1rem;
+    margin-right: 0;
+  }
+  .m-container-inflatable .m-right-l > .m-note,
+  .m-container-inflatable .m-right-l > .m-frame,
+  .m-container-inflatable .m-right-l > .m-block,
+  .m-container-inflatable .m-right-l > .m-imagegrid,
+  .m-container-inflatable .m-right-l > pre,
+  .m-container-inflatable .m-right-l > .m-code-figure,
+  .m-container-inflatable .m-right-l > .m-console-figure {
+    margin-left: 0;
+    margin-right: -1rem;
+  }
+  .m-container-inflatable > .m-row > .m-col-l-10 > .m-imagegrid.m-container-inflate,
+  .m-container-inflatable > .m-row > .m-col-l-10 section > .m-imagegrid.m-container-inflate {
+    margin-left: -10%;
+    margin-right: -10%;
+  }
+}
+pre.m-code span.hll {
+  margin-left: -1.0rem;
+  margin-right: -1.0rem;
+  padding-left: 1.0rem;
+}
+.m-code.m-inverted {
+  color: rgba(91, 91, 91, 0.33);
+}
+.m-code.m-inverted > span {
+  opacity: 0.3333;
+}
+.m-code.m-inverted > span.hll {
+  color: #000000;
+  opacity: 1;
+  background-color: transparent;
+  border-color: transparent;
+}
+.m-code-color {
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  vertical-align: -0.05rem;
+  margin-left: 0.2rem;
+  margin-right: 0.1rem;
+  border-radius: 0.1rem;
+}
+div.m-math {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+div.m-math svg {
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+div.m-button a svg.m-math { fill: #ffffff; }
+div.m-button.m-flat a svg.m-math { fill: #000000; }
+div.m-button.m-flat a:hover svg.m-math, div.m-button.m-default a:focus svg.m-math,
+div.m-button.m-default a:active svg.m-math {
+  fill: #cb4b16;
+}
+.m-graph { font-size: 14px; }
+div.m-plot svg, div.m-graph svg {
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+div.m-plot .m-background { fill: #fbf0ec; }
+div.m-plot svg .m-label { font-size: 11px; }
+div.m-plot svg .m-title { font-size: 13px; }
+div.m-plot svg .m-label, div.m-plot svg .m-title { fill: #000000; }
+div.m-plot svg .m-line {
+  stroke: #000000;
+  stroke-width: 0.8;
+}
+div.m-plot svg .m-error {
+  stroke: #000000;
+  stroke-width: 1.5;
+}
+div.m-plot svg .m-label.m-dim { fill: #bdbdbd; }
+.m-graph g.m-edge path, .m-graph g.m-node.m-flat ellipse,
+.m-graph g.m-node.m-flat polygon {
+  fill: none;
+}
+.m-graph g.m-node:not(.m-flat) text {
+  fill: #ffffff;
+}
+figure.m-figure > svg.m-math:first-child,
+figure.m-figure > svg.m-graph:first-child {
+  padding: 1rem;
+  box-sizing: content-box;
+}
+figure.m-figure:not(.m-flat) > svg.m-math:first-child,
+figure.m-figure:not(.m-flat) > svg.m-graph:first-child {
+  background-color: #f7e3db;
+}
+.m-block.m-default { border-left-color: #f7e3db; }
+.m-block.m-default h3, .m-block.m-default h4, .m-block.m-default h5, .m-block.m-default h6,
+.m-text.m-default, .m-label.m-flat.m-default {
+  color: #000000;
+}
+.m-block.m-default h3 a, .m-block.m-default h4 a, .m-block.m-default h5 a, .m-block.m-default h6 a {
+  color: #ea7944;
+}
+.m-block.m-primary { border-left-color: #cb4b16; }
+.m-block.m-primary h3, .m-block.m-primary h4, .m-block.m-primary h5, .m-block.m-primary h6,
+.m-block.m-primary h3 a, .m-block.m-primary h4 a, .m-block.m-primary h5 a, .m-block.m-primary h6 a,
+.m-text.m-primary, .m-label.m-flat.m-primary {
+  color: #cb4b16;
+}
+.m-block.m-success { border-left-color: #31c25d; }
+.m-block.m-success h3, .m-block.m-success h4, .m-block.m-success h5, .m-block.m-success h6,
+.m-block.m-success h3 a, .m-block.m-success h4 a, .m-block.m-success h5 a, .m-block.m-success h6 a,
+.m-text.m-success, .m-label.m-flat.m-success {
+  color: #31c25d;
+}
+.m-block.m-warning { border-left-color: #c7cf2f; }
+.m-block.m-warning h3, .m-block.m-warning h4, .m-block.m-warning h5, .m-block.m-warning h6,
+.m-block.m-warning h3 a, .m-block.m-warning h4 a, .m-block.m-warning h5 a, .m-block.m-warning h6 a,
+.m-text.m-warning, .m-label.m-flat.m-warning {
+  color: #c7cf2f;
+}
+.m-block.m-danger { border-left-color: #f60000; }
+.m-block.m-danger h3, .m-block.m-danger h4, .m-block.m-danger h5, .m-block.m-danger h6,
+.m-block.m-danger h3 a, .m-block.m-danger h4 a, .m-block.m-danger h5 a, .m-block.m-danger h6 a,
+.m-text.m-danger, .m-label.m-flat.m-danger {
+  color: #f60000;
+}
+.m-block.m-info { border-left-color: #2e7dc5; }
+.m-block.m-info h3, .m-block.m-info h4, .m-block.m-info h5, .m-block.m-info h6,
+.m-block.m-info h3 a, .m-block.m-info h4 a, .m-block.m-info h5 a, .m-block.m-info h6 a,
+.m-text.m-info, .m-label.m-flat.m-info {
+  color: #2e7dc5;
+}
+.m-block.m-dim { border-left-color: #bdbdbd; }
+.m-block.m-dim, .m-text.m-dim, .m-label.m-flat.m-dim {
+  color: #bdbdbd;
+}
+.m-block.m-dim a, .m-text.m-dim a { color: #c0c0c0; }
+.m-block.m-dim a:hover, .m-block.m-dim a:focus, .m-block.m-dim a:active,
+.m-text.m-dim a:hover, .m-text.m-dim a:focus, .m-text.m-dim a:active {
+  color: #949494;
+}
+.m-block.m-flat { border-color: transparent; }
+.m-block.m-flat h3, .m-block.m-flat h4, .m-block.m-flat h5. .m-block.m-flat h6 {
+  color: #000000;
+}
+.m-block.m-default h3 a:hover, .m-block.m-default h3 a:focus, .m-block.m-default h3 a:active,
+.m-block.m-default h4 a:hover, .m-block.m-default h4 a:focus, .m-block.m-default h4 a:active,
+.m-block.m-default h5 a:hover, .m-block.m-default h5 a:focus, .m-block.m-default h5 a:active,
+.m-block.m-default h6 a:hover, .m-block.m-default h6 a:focus, .m-block.m-default h6 a:active {
+  color: #cb4b16;
+}
+.m-block.m-primary h3 a:hover, .m-block.m-primary h3 a:focus, .m-block.m-primary h3 a:active,
+.m-block.m-primary h4 a:hover, .m-block.m-primary h4 a:focus, .m-block.m-primary h4 a:active,
+.m-block.m-primary h5 a:hover, .m-block.m-primary h5 a:focus, .m-block.m-primary h5 a:active,
+.m-block.m-primary h6 a:hover, .m-block.m-primary h6 a:focus, .m-block.m-primary h6 a:active {
+  color: #000000;
+}
+.m-block.m-success h3 a:hover, .m-block.m-success h3 a:focus, .m-block.m-success h3 a:active,
+.m-block.m-success h4 a:hover, .m-block.m-success h4 a:focus, .m-block.m-success h4 a:active,
+.m-block.m-success h5 a:hover, .m-block.m-success h5 a:focus, .m-block.m-success h5 a:active,
+.m-block.m-success h6 a:hover, .m-block.m-success h6 a:focus, .m-block.m-success h6 a:active {
+  color: #dcf6e3;
+}
+.m-block.m-warning h3 a:hover, .m-block.m-warning h3 a:focus, .m-block.m-warning h3 a:active,
+.m-block.m-warning h4 a:hover, .m-block.m-warning h4 a:focus, .m-block.m-warning h4 a:active,
+.m-block.m-warning h5 a:hover, .m-block.m-warning h5 a:focus, .m-block.m-warning h5 a:active,
+.m-block.m-warning h6 a:hover, .m-block.m-warning h6 a:focus, .m-block.m-warning h6 a:active {
+  color: #f6f6dc;
+}
+.m-block.m-danger h3 a:hover, .m-block.m-danger h3 a:focus, .m-block.m-danger h3 a:active,
+.m-block.m-danger h4 a:hover, .m-block.m-danger h4 a:focus, .m-block.m-danger h4 a:active,
+.m-block.m-danger h5 a:hover, .m-block.m-danger h5 a:focus, .m-block.m-danger h5 a:active,
+.m-block.m-danger h6 a:hover, .m-block.m-danger h6 a:focus, .m-block.m-danger h6 a:active {
+  color: #f6dddc;
+}
+.m-block.m-info h3 a:hover, .m-block.m-info h3 a:focus, .m-block.m-info h3 a:active,
+.m-block.m-info h4 a:hover, .m-block.m-info h4 a:focus, .m-block.m-info h4 a:active,
+.m-block.m-info h5 a:hover, .m-block.m-info h5 a:focus, .m-block.m-info h5 a:active,
+.m-block.m-info h6 a:hover, .m-block.m-info h6 a:focus, .m-block.m-info h6 a:active {
+  color: #c6ddf2;
+}
+div.m-button a, .m-label { color: #ffffff; }
+div.m-button.m-flat a { color: #000000; }
+div.m-button.m-flat a:hover, div.m-button.m-default a:focus, div.m-button.m-default a:active {
+  color: #cb4b16;
+}
+div.m-button.m-default a, .m-label:not(.m-flat).m-default { background-color: #000000; }
+div.m-button.m-primary a, .m-label:not(.m-flat).m-primary { background-color: #cb4b16; }
+div.m-button.m-success a, .m-label:not(.m-flat).m-success { background-color: #31c25d; }
+div.m-button.m-warning a, .m-label:not(.m-flat).m-warning { background-color: #c7cf2f; }
+div.m-button.m-danger a, .m-label:not(.m-flat).m-danger { background-color: #f60000; }
+div.m-button.m-info a, .m-label:not(.m-flat).m-info { background-color: #2e7dc5; }
+div.m-button.m-dim a, .m-label:not(.m-flat).m-dim { background-color: #bdbdbd; }
+div.m-button.m-default a:hover, div.m-button.m-default a:focus, div.m-button.m-default a:active {
+  background-color: #cb4b16;
+}
+div.m-button.m-primary a:hover, div.m-button.m-primary a:focus, div.m-button.m-primary a:active {
+  background-color: #000000;
+}
+div.m-button.m-success a:hover, div.m-button.m-success a:focus, div.m-button.m-success a:active {
+  background-color: #dcf6e3;
+}
+div.m-button.m-warning a:hover, div.m-button.m-warning a:focus, div.m-button.m-warning a:active {
+  background-color: #f6f6dc;
+}
+div.m-button.m-danger a:hover, div.m-button.m-danger a:focus, div.m-button.m-danger a:active {
+  background-color: #f6dddc;
+}
+div.m-button.m-info a:hover, div.m-button.m-info a:focus, div.m-button.m-info a:active {
+  background-color: #c6ddf2;
+}
+div.m-button.m-dim a:hover, div.m-button.m-dim a:focus, div.m-button.m-dim a:active {
+  background-color: #c0c0c0;
+}
+.m-note.m-default { background-color: #fbf0ec; }
+.m-note.m-default,
+table.m-table tr.m-default td, table.m-table td.m-default,
+table.m-table tr.m-default th, table.m-table th.m-default {
+  color: #000000;
+}
+.m-note.m-default a:hover,
+table.m-table tr.m-default td a:hover, table.m-table td.m-default a:hover,
+table.m-table tr.m-default th a:hover, table.m-table th.m-default a:hover,
+.m-note.m-default a:focus,
+table.m-table tr.m-default td a:focus, table.m-table td.m-default a:focus,
+table.m-table tr.m-default th a:focus, table.m-table th.m-default a:focus,
+.m-note.m-default a:active,
+table.m-table tr.m-default td a:active, table.m-table td.m-default a:active,
+table.m-table tr.m-default th a:active, table.m-table th.m-default a:active {
+  color: #cb4b16;
+}
+.m-note.m-primary a,
+table.m-table tr.m-primary td a, table.m-table td.m-primary a,
+table.m-table tr.m-primary th a, table.m-table th.m-primary a {
+  color: #ea7944;
+}
+.m-note.m-primary,
+table.m-table tr.m-primary td, table.m-table td.m-primary,
+table.m-table tr.m-primary th, table.m-table th.m-primary {
+  background-color: #ef9069;
+  color: #fbe4d9;
+}
+.m-note.m-primary a,
+table.m-table tr.m-primary td a, table.m-table td.m-primary a,
+table.m-table tr.m-primary th a, table.m-table th.m-primary a {
+  color: #782f0d;
+}
+.m-note.m-primary a:hover,
+table.m-table tr.m-primary td a:hover, table.m-table td.m-primary a:hover,
+table.m-table tr.m-primary th a:hover, table.m-table th.m-primary a:hover,
+.m-note.m-primary a:focus,
+table.m-table tr.m-primary td a:focus, table.m-table td.m-primary a:focus,
+table.m-table tr.m-primary th a:focus, table.m-table th.m-primary a:focus,
+.m-note.m-primary a:active,
+table.m-table tr.m-primary td a:active, table.m-table td.m-primary a:active,
+table.m-table tr.m-primary th a:active, table.m-table th.m-primary a:active {
+  color: #2f1205;
+}
+.m-note.m-success,
+table.m-table tr.m-success td, table.m-table td.m-success,
+table.m-table tr.m-success th, table.m-table th.m-success {
+  background-color: #4dd376;
+  color: #f4fcf6;
+}
+.m-note.m-success a,
+table.m-table tr.m-success td a, table.m-table td.m-success a,
+table.m-table tr.m-success th a, table.m-table th.m-success a {
+  color: #c5f2d1;
+}
+.m-note.m-success a:hover,
+table.m-table tr.m-success td a:hover, table.m-table td.m-success a:hover,
+table.m-table tr.m-success th a:hover, table.m-table th.m-success a:hover,
+.m-note.m-success a:focus,
+table.m-table tr.m-success td a:focus, table.m-table td.m-success a:focus,
+table.m-table tr.m-success th a:focus, table.m-table th.m-success a:focus,
+.m-note.m-success a:active,
+table.m-table tr.m-success td a:active, table.m-table td.m-success a:active,
+table.m-table tr.m-success th a:active, table.m-table th.m-success a:active {
+  color: #dcf6e3;
+}
+.m-note.m-warning, table.m-table tr.m-warning td, table.m-table td.m-warning,
+                   table.m-table tr.m-warning th, table.m-table th.m-warning {
+  background-color: #d1d34d;
+  color: #fcfcf4;
+}
+.m-note.m-warning a, table.m-table tr.m-warning td a, table.m-table td.m-warning a,
+                     table.m-table tr.m-warning th a, table.m-table th.m-warning a {
+  color: #f0f1c7;
+}
+.m-note.m-warning a:hover,
+table.m-table tr.m-warning td a:hover, table.m-table td.m-warning a:hover,
+table.m-table tr.m-warning th a:hover, table.m-table th.m-warning a:hover,
+.m-note.m-warning a:focus,
+table.m-table tr.m-warning td a:focus, table.m-table td.m-warning a:focus,
+table.m-table tr.m-warning th a:focus, table.m-table th.m-warning a:focus,
+.m-note.m-warning a:active,
+table.m-table tr.m-warning td a:active, table.m-table td.m-warning a:active,
+table.m-table tr.m-warning th a:active, table.m-table th.m-warning a:active {
+  color: #f6f6dc;
+}
+.m-note.m-danger,
+table.m-table tr.m-danger td, table.m-table td.m-danger,
+table.m-table tr.m-danger th, table.m-table th.m-danger {
+  background-color: #e23e3e;
+  color: #fdf3f3;
+}
+.m-note.m-danger a,
+table.m-table tr.m-danger td a, table.m-table td.m-danger a,
+table.m-table tr.m-danger th a, table.m-table th.m-danger a {
+  color: #f2c7c6;
+}
+.m-note.m-danger a:hover,
+table.m-table tr.m-danger td a:hover, table.m-table td.m-danger a:hover,
+table.m-table tr.m-danger th a:hover, table.m-table th.m-danger a:hover,
+.m-note.m-danger a:focus,
+table.m-table tr.m-danger td a:focus, table.m-table td.m-danger a:focus,
+table.m-table tr.m-danger th a:focus, table.m-table th.m-danger a:focus,
+.m-note.m-danger a:active,
+table.m-table tr.m-danger td a:active, table.m-table td.m-danger a:active,
+table.m-table tr.m-danger th a:active, table.m-table th.m-danger a:active {
+  color: #f6dddc;
+}
+.m-note.m-info,
+table.m-table tr.m-info td, table.m-table td.m-info,
+table.m-table tr.m-info th, table.m-table th.m-info {
+  background-color: #4c93d3;
+  color: #f4f8fc;
+}
+.m-note.m-info a,
+table.m-table tr.m-info td a, table.m-table td.m-info a,
+table.m-table tr.m-info th a, table.m-table th.m-info a {
+  color: #c6ddf2;
+}
+.m-note.m-info a:hover,
+table.m-table tr.m-info td a:hover, table.m-table td.m-info a:hover,
+table.m-table tr.m-info th a:hover, table.m-table th.m-info a:hover,
+.m-note.m-info a:focus,
+table.m-table tr.m-info td a:focus, table.m-table td.m-info a:focus,
+table.m-table tr.m-info th a:focus, table.m-table th.m-info a:focus,
+.m-note.m-info a:active,
+table.m-table tr.m-info td a:active, table.m-table td.m-info a:active,
+table.m-table tr.m-info th a:active, table.m-table th.m-info a:active {
+  color: #dbeaf7;
+}
+.m-note.m-dim,
+table.m-table tr.m-dim td, table.m-table td.m-dim,
+table.m-table tr.m-dim th, table.m-table th.m-dim {
+  background-color: #f1f1f1;
+  color: #7c7c7c;
+}
+.m-note.m-dim a,
+table.m-table tr.m-dim td a, table.m-table td.m-dim a,
+table.m-table tr.m-dim th a, table.m-table th.m-dim a {
+  color: #c0c0c0;
+}
+.m-note.m-dim a:hover,
+table.m-table tr.m-dim td a:hover, table.m-table td.m-dim a:hover,
+table.m-table tr.m-dim th a:hover, table.m-table th.m-dim a:hover,
+.m-note.m-dim a:focus,
+table.m-table tr.m-dim td a:focus, table.m-table td.m-dim a:focus,
+table.m-table tr.m-dim th a:focus, table.m-table th.m-dim a:focus,
+.m-note.m-dim a:active,
+table.m-table tr.m-dim td a:active, table.m-table td.m-dim a:active,
+table.m-table tr.m-dim th a:active, table.m-table th.m-dim a:active {
+  color: #949494;
+}
+figure.m-figure.m-default:before { border-color: #fbf0ec; }
+figure.m-figure.m-default figcaption { color: #000000; }
+figure.m-figure.m-primary:before { border-color: #ef9069; }
+figure.m-figure.m-primary figcaption { color: #cb4b16; }
+figure.m-figure.m-success:before { border-color: #4dd376; }
+figure.m-figure.m-success figcaption { color: #31c25d; }
+figure.m-figure.m-warning:before { border-color: #d1d34d; }
+figure.m-figure.m-warning figcaption { color: #c7cf2f; }
+figure.m-figure.m-danger:before { border-color: #e23e3e; }
+figure.m-figure.m-danger figcaption { color: #f60000; }
+figure.m-figure.m-info:before { border-color: #4c93d3; }
+figure.m-figure.m-info figcaption { color: #2e7dc5; }
+figure.m-figure.m-dim:before { border-color: #f1f1f1; }
+figure.m-figure.m-dim { color: #bdbdbd; }
+figure.m-figure.m-dim a { color: #c0c0c0; }
+figure.m-figure.m-dim a:hover, figure.m-figure.m-dim a:focus, figure.m-figure.m-dim a:active {
+  color: #949494;
+}
+.m-math { fill: #000000; }
+.m-math.m-default, .m-math g.m-default, .m-math rect.m-default,
+div.m-plot svg .m-bar.m-default,
+.m-graph g.m-edge polygon,
+.m-graph g.m-node:not(.m-flat) ellipse,
+.m-graph g.m-node:not(.m-flat) polygon,
+.m-graph g.m-edge text,
+.m-graph g.m-node.m-flat text,
+.m-graph.m-default g.m-edge polygon,
+.m-graph.m-default g.m-node:not(.m-flat) ellipse,
+.m-graph.m-default g.m-node:not(.m-flat) polygon,
+.m-graph.m-default g.m-edge text,
+.m-graph.m-default g.m-node.m-flat text {
+  fill: #000000;
+}
+.m-graph g.m-edge polygon,
+.m-graph g.m-edge path,
+.m-graph g.m-node ellipse,
+.m-graph g.m-node polygon,
+.m-graph g.m-node polyline,
+.m-graph.m-default g.m-edge polygon,
+.m-graph.m-default g.m-edge path,
+.m-graph.m-default g.m-node ellipse,
+.m-graph.m-default g.m-node polygon,
+.m-graph.m-default g.m-node polyline {
+  stroke: #000000;
+}
+.m-math.m-primary, .m-math g.m-primary, .m-math rect.m-primary,
+div.m-plot svg .m-bar.m-primary,
+.m-graph.m-primary g.m-edge polygon,
+.m-graph.m-primary g.m-node:not(.m-flat) ellipse,
+.m-graph.m-primary g.m-node:not(.m-flat) polygon,
+.m-graph.m-primary g.m-edge text,
+.m-graph.m-primary g.m-node.m-flat text {
+  fill: #cb4b16;
+}
+.m-graph.m-primary g.m-edge polygon,
+.m-graph.m-primary g.m-edge path,
+.m-graph.m-primary g.m-node ellipse,
+.m-graph.m-primary g.m-node polygon,
+.m-graph.m-primary g.m-node polyline {
+  stroke: #cb4b16;
+}
+.m-math.m-success, .m-math g.m-success, .m-math rect.m-success,
+div.m-plot svg .m-bar.m-success,
+.m-graph.m-success g.m-edge polygon,
+.m-graph.m-success g.m-node:not(.m-flat) ellipse,
+.m-graph.m-success g.m-node:not(.m-flat) polygon,
+.m-graph.m-success g.m-edge text,
+.m-graph.m-success g.m-node.m-flat text {
+  fill: #31c25d;
+}
+.m-graph.m-success g.m-edge polygon,
+.m-graph.m-success g.m-edge path,
+.m-graph.m-success g.m-node ellipse,
+.m-graph.m-success g.m-node polygon,
+.m-graph.m-success g.m-node polyline {
+  stroke: #31c25d;
+}
+.m-math.m-warning, .m-math g.m-warning, .m-math rect.m-warning,
+div.m-plot svg .m-bar.m-warning,
+.m-graph.m-warning g.m-edge polygon,
+.m-graph.m-warning g.m-node:not(.m-flat) ellipse,
+.m-graph.m-warning g.m-node:not(.m-flat) polygon,
+.m-graph.m-warning g.m-edge text,
+.m-graph.m-warning g.m-node.m-flat text {
+  fill: #c7cf2f;
+}
+.m-graph.m-warning g.m-edge polygon,
+.m-graph.m-warning g.m-edge path,
+.m-graph.m-warning g.m-node ellipse,
+.m-graph.m-warning g.m-node polygon,
+.m-graph.m-warning g.m-node polyline {
+  stroke: #c7cf2f;
+}
+.m-math.m-danger, .m-math g.m-danger, .m-math rect.m-danger,
+div.m-plot svg .m-bar.m-danger,
+.m-graph.m-danger g.m-edge polygon,
+.m-graph.m-danger g.m-node:not(.m-flat) ellipse,
+.m-graph.m-danger g.m-node:not(.m-flat) polygon,
+.m-graph.m-danger g.m-edge text,
+.m-graph.m-danger g.m-node.m-flat text {
+  fill: #f60000;
+}
+.m-graph.m-danger g.m-edge polygon,
+.m-graph.m-danger g.m-edge path,
+.m-graph.m-danger g.m-node ellipse,
+.m-graph.m-danger g.m-node polygon,
+.m-graph.m-danger g.m-node polyline {
+  stroke: #f60000;
+}
+.m-math.m-info, .m-math g.m-info, .m-math rect.m-info,
+div.m-plot svg .m-bar.m-info,
+.m-graph.m-info g.m-edge polygon,
+.m-graph.m-info g.m-node:not(.m-flat) ellipse,
+.m-graph.m-info g.m-node:not(.m-flat) polygon,
+.m-graph.m-info g.m-edge text,
+.m-graph.m-info g.m-node.m-flat text {
+  fill: #2e7dc5;
+}
+.m-graph.m-info g.m-edge polygon,
+.m-graph.m-info g.m-edge path,
+.m-graph.m-info g.m-node ellipse,
+.m-graph.m-info g.m-node polygon,
+.m-graph.m-info g.m-node polyline {
+  stroke: #2e7dc5;
+}
+.m-math.m-dim, .m-math g.m-dim, .m-math rect.m-dim,
+div.m-plot svg .m-bar.m-dim,
+.m-graph.m-dim g.m-edge polygon,
+.m-graph.m-dim g.m-node:not(.m-flat) ellipse,
+.m-graph.m-dim g.m-node:not(.m-flat) polygon,
+.m-graph.m-dim g.m-edge text,
+.m-graph.m-dim g.m-node.m-flat text {
+  fill: #bdbdbd;
+}
+.m-graph.m-dim g.m-edge polygon,
+.m-graph.m-dim g.m-edge path,
+.m-graph.m-dim g.m-node ellipse,
+.m-graph.m-dim g.m-node polygon,
+.m-graph.m-dim g.m-node polyline {
+  stroke: #bdbdbd;
+}
+.m-graph g.m-edge.m-default polygon,
+.m-graph g.m-node.m-default:not(.m-flat) ellipse,
+.m-graph g.m-node.m-default:not(.m-flat) polygon,
+.m-graph g.m-edge.m-default text,
+.m-graph g.m-node.m-default.m-flat text {
+  fill: #000000;
+}
+.m-graph g.m-edge.m-default polygon,
+.m-graph g.m-edge.m-default path,
+.m-graph g.m-node.m-default ellipse,
+.m-graph g.m-node.m-default polygon,
+.m-graph g.m-node.m-default polyline {
+  stroke: #000000;
+}
+.m-graph g.m-edge.m-primary polygon,
+.m-graph g.m-node.m-primary:not(.m-flat) ellipse,
+.m-graph g.m-node.m-primary:not(.m-flat) polygon,
+.m-graph g.m-edge.m-primary text,
+.m-graph g.m-node.m-primary.m-flat text {
+  fill: #cb4b16;
+}
+.m-graph g.m-edge.m-primary polygon,
+.m-graph g.m-edge.m-primary path,
+.m-graph g.m-node.m-primary ellipse,
+.m-graph g.m-node.m-primary polygon,
+.m-graph g.m-node.m-primary polyline {
+  stroke: #cb4b16;
+}
+.m-graph g.m-edge.m-success polygon,
+.m-graph g.m-node.m-success:not(.m-flat) ellipse,
+.m-graph g.m-node.m-success:not(.m-flat) polygon,
+.m-graph g.m-edge.m-success text,
+.m-graph g.m-node.m-success.m-flat text {
+  fill: #31c25d;
+}
+.m-graph g.m-edge.m-success polygon,
+.m-graph g.m-edge.m-success path,
+.m-graph g.m-node.m-success ellipse,
+.m-graph g.m-node.m-success polygon,
+.m-graph g.m-node.m-success polyline {
+  stroke: #31c25d;
+}
+.m-graph g.m-edge.m-warning polygon,
+.m-graph g.m-node.m-warning:not(.m-flat) ellipse,
+.m-graph g.m-node.m-warning:not(.m-flat) polygon,
+.m-graph g.m-edge.m-warning text,
+.m-graph g.m-node.m-warning.m-flat text {
+  fill: #c7cf2f;
+}
+.m-graph g.m-edge.m-warning polygon,
+.m-graph g.m-edge.m-warning path,
+.m-graph g.m-node.m-warning ellipse,
+.m-graph g.m-node.m-warning polygon,
+.m-graph g.m-node.m-warning polyline {
+  stroke: #c7cf2f;
+}
+.m-graph g.m-edge.m-danger polygon,
+.m-graph g.m-node.m-danger:not(.m-flat) ellipse,
+.m-graph g.m-node.m-danger:not(.m-flat) polygon,
+.m-graph g.m-edge.m-danger text,
+.m-graph g.m-node.m-danger.m-flat text {
+  fill: #f60000;
+}
+.m-graph g.m-edge.m-danger polygon,
+.m-graph g.m-edge.m-danger path,
+.m-graph g.m-node.m-danger ellipse,
+.m-graph g.m-node.m-danger polygon,
+.m-graph g.m-node.m-danger polyline {
+  stroke: #f60000;
+}
+.m-graph g.m-edge.m-info polygon,
+.m-graph g.m-node.m-info:not(.m-flat) ellipse,
+.m-graph g.m-node.m-info:not(.m-flat) polygon,
+.m-graph g.m-edge.m-info text,
+.m-graph g.m-node.m-info.m-flat text {
+  fill: #2e7dc5;
+}
+.m-graph g.m-edge.m-info polygon,
+.m-graph g.m-edge.m-info path,
+.m-graph g.m-node.m-info ellipse,
+.m-graph g.m-node.m-info polygon,
+.m-graph g.m-node.m-info polyline {
+  stroke: #2e7dc5;
+}
+.m-graph g.m-edge.m-dim polygon,
+.m-graph g.m-node.m-dim:not(.m-flat) ellipse,
+.m-graph g.m-node.m-dim:not(.m-flat) polygon,
+.m-graph g.m-edge.m-dim text,
+.m-graph g.m-node.m-dim.m-flat text {
+  fill: #bdbdbd;
+}
+.m-graph g.m-edge.m-dim polygon,
+.m-graph g.m-edge.m-dim path,
+.m-graph g.m-node.m-dim ellipse,
+.m-graph g.m-node.m-dim polygon,
+.m-graph g.m-node.m-dim polyline {
+  stroke: #bdbdbd;
+}
+p, ul, ol, dl, blockquote, pre, .m-code-figure, .m-console-figure, hr, .m-note,
+.m-frame, .m-block, div.m-button, div.m-scroll, table.m-table, div.m-image,
+img.m-image, svg.m-image, figure.m-figure, .m-imagegrid, div.m-math,
+div.m-graph, div.m-plot {
+  margin-bottom: 1rem;
+}
+p:last-child, p.m-nopadb, ul:last-child, ul.m-nopadb,
+ol:last-child, ol.m-nopadb, dl:last-child, dl.m-nopadb,
+blockquote:last-child, blockquote.m-nopadb, pre:last-child, pre.m-nopadb,
+.m-code-figure:last-child, .m-code-figure.m-nopadb,
+.m-console-figure:last-child, .m-console-figure.m-nopadb,
+hr:last-child, hr.m-nopadb, .m-note:last-child, .m-note.m-nopadb,
+.m-frame:last-child, .m-frame.m-nopadb, .m-block:last-child, .m-block.m-nopadb,
+div.m-button:last-child, div.m-button.m-nopadb,
+div.m-scroll:last-child, div.m-scroll.m-nopadb,
+table.m-table:last-child, table.m-table.m-nopadb,
+img.m-image:last-child, img.m-image.m-nopadb,
+svg.m-image:last-child, svg.m-image.m-nopadb,
+div.m-image:last-child, div.m-image.m-nopadb,
+figure.m-figure:last-child, figure.m-figure.m-nopadb,
+.m-imagegrid:last-child, .m-imagegrid.m-nopadb,
+div.m-math:last-child, div.m-math.m-nopadb,
+div.m-graph:last-child, div.m-graph.m-nopadb,
+div.m-plot:last-child, div.m-plot.m-nopadb {
+  margin-bottom: 0;
+}
+li > p:last-child, li > blockquote:last-child, li > pre:last-child,
+li > .m-code-figure:last-child, li > .m-console-figure:last-child,
+li > .m-note:last-child, li > .m-frame:last-child, li > .m-block:last-child,
+li > div.m-button:last-child, li > div.m-scroll:last-child, li > table.m-table:last-child,
+li > img.m-image:last-child, li > svg.m-image:last-child, li > div.m-image:last-child,
+li > figure.m-figure:last-child, li > div.m-math:last-child,
+li > div.m-graph:last-child, li > div.m-plot:last-child {
+  margin-bottom: 1rem;
+}
+li:last-child > p:last-child, li:last-child > p.m-nopadb,
+li:last-child > blockquote:last-child, li:last-child > blockquote.m-nopadb,
+li:last-child > pre:last-child, li:last-child > pre.m-nopadb,
+li:last-child > .m-code-figure:last-child, li:last-child > .m-code-figure.m-nopadb,
+li:last-child > .m-console-figure:last-child, li:last-child > .m-console-figure.m-nopadb,
+li:last-child > .m-note:last-child, li:last-child > .m-note.m-nopadb,
+li:last-child > .m-frame:last-child, li:last-child > .m-frame.m-nopadb,
+li:last-child > .m-block:last-child, li:last-child > .m-block.m-nopadb,
+li:last-child > div.m-button:last-child, li:last-child > div.m-button.m-nopadb,
+li:last-child > div.m-scroll:last-child, li:last-child > div.m-scroll.m-nopadb,
+li:last-child > table.m-table:last-child, li:last-child > table.m-table.m-nopadb,
+li:last-child > img.m-image:last-child, li:last-child > img.m-image.m-nopadb,
+li:last-child > svg.m-image:last-child, li:last-child > svg.m-image.m-nopadb,
+li:last-child > div.m-image:last-child, li:last-child > div.m-image.m-nopadb,
+li:last-child > figure.m-figure:last-child, li:last-child > figure.m-figure.m-nopadb,
+li:last-child > div.m-math:last-child, li:last-child > div.m-math.m-nopadb,
+li:last-child > div.m-graph:last-child, li:last-child > div.m-graph.m-nopadb,
+li:last-child > div.m-plot:last-child, li:last-child > div.m-plot.m-nopadb {
+  margin-bottom: 0;
+}
+
+html {
+  font-size: 2.49vw;
+  background-color: transparent;
+}
+article > aside, article > section {
+  height: 100vh;
+  padding: 1rem;
+}
+article > aside {
+  background-color: #ffffff;
+}
+article > aside > h1 {
+  font-size: 4rem;
+  padding-top: 2rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-bottom: 2rem;
+}
+article > section {
+  position: relative;
+  background-color: #ffffff;
+}
+article > section.m-presentation-cover {
+  background-size: cover;
+  background-color: #ffffff;
+  background-position: center center;
+  background-repeat: no-repeat;
+}
+article > section > h1 {
+  margin: -1rem;
+  padding-top: 7rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  height: 100vh;
+  font-size: 4rem;
+}
+article > section:not(.m-presentation-cover) > h1 {
+  background-color: #ffffff;
+}
+article > section.m-presentation-cover > h1,
+article > section.m-presentation-cover > h2 {
+  color: #ffffff;
+}
+article > section.m-presentation-cover.m-inverted > h1,
+article > section.m-presentation-cover.m-inverted > h2 {
+  color: #000000;
+}
+article > section > h1 + h2 {
+  margin-top: -100vh;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  padding-top: 13rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  font-size: 2rem;
+}
+article > section > h2:first-child {
+  color: #cb4b16;
+  line-height: 3.5rem;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  margin-top: -1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  margin-bottom: 1rem;
+  background-color: #ffffff;
+}
+article > section.m-presentation-background > h2:first-child {
+  background-color: rgba(255, 255, 255, 0.25);
+}
+article > section > nav {
+  font-size: 85.4%;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  padding-bottom: 1.0rem;
+  padding-right: 0.5rem;
+}
+article > section > nav > a {
+  text-decoration: none;
+  display: inline-block;
+  width: 1.5rem;
+}
+article > section > nav > a:link, article > section > nav > a:visited {
+  color: #c0c0c0;
+}
+article > section > nav > a:hover, article > section > nav > a:active {
+  color: #949494;
+}
+article > section > nav > a.m-presentation-cover {
+  text-align: center;
+  width: 2.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+article > section > nav > a.m-presentation-prev { text-align: right; }
+article > section > nav > a.m-presentation-prev::before { content: '«'; }
+article > section > nav > a.m-presentation-next { text-align: left; }
+article > section > nav > a.m-presentation-next::before { content: '»'; }
+article > section > aside.m-presenter {
+  display: none;
+}
+@media screen {
+  html:not(.m-presenter) article > section:first-child {
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    z-index: -1;
+    overflow: hidden;
+  }
+  article > section { display: none; }
+  article > section:target { display: block; }
+}
+html:not(.m-presenter) .m-container { width: 100%; }
+@media print { .m-container { width: 100%; } }
+@media print {
+  article > aside { display: none; }
+  article > section > nav { display: none; }
+  body { -webkit-print-color-adjust: exact; }
+  article > section:last-child { height: 99.99999vh; }
+  article > section:not(:first-of-type) { page-break-before: always; }
+  @page {
+    margin: 0;
+    size: 297mm 167mm;
+  }
+}
+@media screen {
+  html.m-presenter { font-size: 2.381vw; }
+  @media screen and (min-width: 576px) {
+    html.m-presenter { font-size: 13.3333px; }
+  }
+  @media screen and (min-width: 768px) {
+    html.m-presenter { font-size: 14.8809px; }
+  }
+  @media screen and (min-width: 992px) {
+    html.m-presenter { font-size: 19.0476px; }
+  }
+  html.m-presenter body {
+    overflow-y: scroll;
+  }
+  html.m-presenter article {
+    position: relative;
+    margin: 0;
+    padding-top: 56.25%;
+    background-color: #ffffff;
+  }
+  html.m-presenter article > aside,
+  html.m-presenter article > section {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+  }
+  html.m-presenter article > *:first-child {
+  }
+  html.m-presenter article > section > h1 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+    margin: 0;
+  }
+  html.m-presenter article > section > h1 + h2 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    margin: 0;
+  }
+  html.m-presenter article > aside > aside.m-presenter,
+  html.m-presenter article > section > aside.m-presenter {
+    display: block;
+    position: absolute;
+    top: 0;
+    margin-top: 56.25%;
+    color: #000000;
+    font-size: 14px;
+  }
+  html.m-presenter article > aside > aside.m-presenter {
+    padding-top: 1rem;
+  }
+  html.m-presenter article > section > aside.m-presenter {
+    padding-top: 3rem;
+  }
+  html.m-presenter article > section > aside.m-presenter code,
+  html.m-presenter article > section > aside.m-presenter pre {
+    color: #000000;
+    background-color: transparent;
+    font-size: 1em;
+  }
+}
+
+.m-console .hll { background-color: #ffffcc }
+.m-console .g-AnsiBlack { color: #000000 }
+.m-console .g-AnsiBlue { color: #3f3fd1 }
+.m-console .g-AnsiBrightBlack { color: #686868; font-weight: bold }
+.m-console .g-AnsiBrightBlue { color: #5454ff; font-weight: bold }
+.m-console .g-AnsiBrightCyan { color: #54ffff; font-weight: bold }
+.m-console .g-AnsiBrightDefault { color: #ffffff; font-weight: bold }
+.m-console .g-AnsiBrightGreen { color: #54ff54; font-weight: bold }
+.m-console .g-AnsiBrightMagenta { color: #ff54ff; font-weight: bold }
+.m-console .g-AnsiBrightRed { color: #ff5454; font-weight: bold }
+.m-console .g-AnsiBrightWhite { color: #ffffff; font-weight: bold }
+.m-console .g-AnsiBrightYellow { color: #ffff54; font-weight: bold }
+.m-console .g-AnsiCyan { color: #18b2b2 }
+.m-console .g-AnsiDefault { color: #b2b2b2 }
+.m-console .g-AnsiGreen { color: #18b218 }
+.m-console .g-AnsiMagenta { color: #b218b2 }
+.m-console .g-AnsiRed { color: #b21818 }
+.m-console .g-AnsiWhite { color: #b2b2b2 }
+.m-console .g-AnsiYellow { color: #b26818 }
+.m-console .go { color: #b2b2b2 }
+.m-console .gp { color: #54ffff; font-weight: bold }
+.m-console .w { color: #b2b2b2 }

--- a/css/m-light-presentation.compiled.css
+++ b/css/m-light-presentation.compiled.css
@@ -3,7 +3,8 @@
 /*
     This file is part of m.css.
 
-    Copyright © 2017, 2018, 2019 Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2017, 2018, 2019, 2020, 2021, 2022, 2023
+              Vladimír Vondruš <mosra@centrum.cz>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -36,7 +37,7 @@ body { margin: 0; }
   margin-left: -1rem;
   margin-right: -1rem;
 }
-.m-row:after {
+.m-row::after {
   content: ' ';
   clear: both;
   display: table;
@@ -345,6 +346,7 @@ html {
 body {
   font-family: 'Libre Baskerville', serif;
   font-size: 1rem;
+  line-height: normal;
   color: #000000;
 }
 h1, h2, h3, h4, h5, h6 {
@@ -390,23 +392,6 @@ hr {
 blockquote, hr {
   border-color: #f7e3db;
 }
-pre {
-  font-family: 'Source Code Pro', monospace, monospace, monospace;
-  font-size: 1em;
-  padding: 0.5rem 1rem;
-  color: #5b5b5b;
-  background-color: #fbf0ec;
-  border-radius: 0.2rem;
-  overflow-x: auto;
-  margin-top: 0;
-}
-pre.m-console-wrap {
-  white-space: pre-wrap;
-  word-break: break-all;
-}
-pre.m-console {
-  background-color: #000000;
-}
 strong, .m-text.m-strong { font-weight: bold; }
 em, .m-text.m-em { font-style: italic; }
 s, .m-text.m-s { text-decoration: line-through; }
@@ -438,15 +423,31 @@ mark {
   background-color: #e6e69c;
   color: #4c93d3;
 }
-code {
+.m-link-wrap {
+  word-break: break-all;
+}
+pre, code {
   font-family: 'Source Code Pro', monospace, monospace, monospace;
   font-size: 1em;
-  padding: 0.125rem;
   color: #5b5b5b;
   background-color: #fbf0ec;
 }
-code.m-console {
+pre.m-console, code.m-console {
+  color: #5b5b5b;
   background-color: #000000;
+}
+pre {
+  padding: 0.5rem 1rem;
+  border-radius: 0.2rem;
+  overflow-x: auto;
+  margin-top: 0;
+}
+pre.m-console-wrap {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+code {
+  padding: 0.125rem;
 }
 *:focus { outline-color: #ea7944; }
 div.m-scroll {
@@ -542,14 +543,15 @@ dl.m-diary:last-child {
 }
 dl.m-diary dt {
   font-weight: bold;
-  width: 3.5rem;
+  width: 6rem;
   float: left;
   clear: both;
   padding-top: 0.25rem;
 }
 dl.m-diary dd {
   padding-top: 0.25rem;
-  padding-left: 3.5rem;
+  padding-left: 6rem;
+  margin-left: 0;
 }
 a.m-footnote, dl.m-footnote dd span.m-footnote {
   top: -0.35rem;
@@ -764,7 +766,7 @@ table.m-table td.m-dim pre, table.m-table td.m-dim code,
 table.m-table th.m-dim pre, table.m-table th.m-dim code {
   background-color: rgba(251, 240, 236, 0.5);
 }
-img.m-image, svg.m-image {
+img.m-image, svg.m-image, video.m-image {
   display: block;
   margin-left: auto;
   margin-right: auto;
@@ -772,12 +774,18 @@ img.m-image, svg.m-image {
 div.m-image {
   text-align: center;
 }
-img.m-image, svg.m-image, div.m-image img, div.m-image svg {
+img.m-image, svg.m-image, video.m-image,
+div.m-image img, div.m-image svg, div.m-image video {
   max-width: 100%;
   border-radius: 0.2rem;
 }
-div.m-image.m-fullwidth img, div.m-image.m-fullwidth svg {
+div.m-image.m-fullwidth img,
+div.m-image.m-fullwidth svg,
+div.m-image.m-fullwidth video {
   width: 100%;
+}
+img.m-image.m-badge, div.m-image.m-badge img {
+  border-radius: 50%;
 }
 figure.m-figure {
   max-width: 100%;
@@ -787,7 +795,7 @@ figure.m-figure {
   position: relative;
   display: table;
 }
-figure.m-figure:before {
+figure.m-figure::before {
   position: absolute;
   content: ' ';
   top: 0;
@@ -800,7 +808,7 @@ figure.m-figure:before {
   border-radius: 0.2rem;
   border-color: #f7e3db;
 }
-figure.m-figure.m-flat:before {
+figure.m-figure.m-flat::before {
   border-color: transparent;
 }
 figure.m-figure > * {
@@ -815,7 +823,9 @@ figure.m-figure > *:first-child {
 figure.m-figure > *:last-child {
   margin-bottom: 1rem !important;
 }
-figure.m-figure img, figure.m-figure svg {
+figure.m-figure img,
+figure.m-figure svg,
+figure.m-figure video {
   position: relative;
   margin-left: 0;
   margin-right: 0;
@@ -824,11 +834,15 @@ figure.m-figure img, figure.m-figure svg {
   border-top-right-radius: 0.2rem;
   max-width: 100%;
 }
-figure.m-figure.m-flat img, figure.m-figure.m-flat svg {
+figure.m-figure.m-flat img,
+figure.m-figure.m-flat svg,
+figure.m-figure.m-flat video {
   border-bottom-left-radius: 0.2rem;
   border-bottom-right-radius: 0.2rem;
 }
-figure.m-figure a img, figure.m-figure a svg {
+figure.m-figure a img,
+figure.m-figure a svg,
+figure.m-figure a video {
   margin-left: -1rem;
   margin-right: -1rem;
 }
@@ -838,10 +852,12 @@ figure.m-figure.m-fullwidth, figure.m-figure.m-fullwidth > * {
 figure.m-figure.m-fullwidth > *:first-child {
   display: inline;
 }
-figure.m-figure.m-fullwidth img, figure.m-figure.m-fullwidth svg {
+figure.m-figure.m-fullwidth img,
+figure.m-figure.m-fullwidth svg,
+figure.m-figure.m-fullwidth video {
   width: 100%;
 }
-figure.m-figure.m-fullwidth:after {
+figure.m-figure.m-fullwidth::after {
   content: ' ';
   display: block;
   margin-top: 1rem;
@@ -854,7 +870,7 @@ figure.m-figure.m-fullwidth:after {
   position: relative;
   padding: 1rem;
 }
-.m-code-figure:before, .m-console-figure:before {
+.m-code-figure::before, .m-console-figure::before {
   position: absolute;
   content: ' ';
   top: 0;
@@ -866,13 +882,13 @@ figure.m-figure.m-fullwidth:after {
   border-width: 0.125rem;
   border-radius: 0.2rem;
 }
-.m-code-figure:before {
+.m-code-figure::before {
   border-color: #fbf0ec;
 }
-.m-console-figure:before {
+.m-console-figure::before {
   border-color: #000000;
 }
-.m-code-figure.m-flat:before, .m-console-figure.m-flat:before {
+.m-code-figure.m-flat::before, .m-console-figure.m-flat::before {
   border-color: transparent;
 }
 .m-code-figure > pre:first-child, .m-console-figure > pre:first-child {
@@ -893,6 +909,17 @@ figure.m-figure figcaption, .m-code-figure figcaption, .m-console-figure figcapt
   margin-bottom: 0.5rem;
   font-weight: normal;
   font-size: 1.17rem;
+}
+figure.m-figure figcaption a, .m-code-figure figcaption a, .m-console-figure figcaption a {
+  text-decoration: none;
+}
+figure.m-figure figcaption .m-figure-description {
+  margin-top: 0.5rem;
+  font-weight: normal;
+  font-size: 1rem;
+}
+figure.m-figure figcaption .m-figure-description a {
+  text-decoration: underline;
 }
 .m-imagegrid > div {
   background-color: #ffffff;
@@ -1137,18 +1164,18 @@ pre.m-code span.hll {
   margin-right: -1.0rem;
   padding-left: 1.0rem;
 }
-.m-code.m-inverted {
-  color: rgba(91, 91, 91, 0.33);
-}
-.m-code.m-inverted > span {
+.m-code.m-inverted > span, .m-console.m-inverted > span {
   opacity: 0.3333;
 }
-.m-code.m-inverted > span.hll {
-  color: #000000;
+.m-code.m-inverted > span.hll, .m-console.m-inverted > span.hll {
   opacity: 1;
   background-color: transparent;
   border-color: transparent;
 }
+.m-code.m-inverted { color: rgba(91, 91, 91, 0.33); }
+.m-console.m-inverted { color: rgba(91, 91, 91, 0.33); }
+.m-code.m-inverted > span.hll { color: #5b5b5b; }
+.m-cosole.m-inverted > span.hll { color: #5b5b5b; }
 .m-code-color {
   display: inline-block;
   width: 0.75rem;
@@ -1193,7 +1220,8 @@ div.m-plot svg .m-error {
   stroke-width: 1.5;
 }
 div.m-plot svg .m-label.m-dim { fill: #bdbdbd; }
-.m-graph g.m-edge path, .m-graph g.m-node.m-flat ellipse,
+.m-graph g.m-edge path, .m-graph g.m-cluster polygon,
+.m-graph g.m-node.m-flat ellipse,
 .m-graph g.m-node.m-flat polygon {
   fill: none;
 }
@@ -1257,7 +1285,7 @@ figure.m-figure:not(.m-flat) > svg.m-graph:first-child {
   color: #949494;
 }
 .m-block.m-flat { border-color: transparent; }
-.m-block.m-flat h3, .m-block.m-flat h4, .m-block.m-flat h5. .m-block.m-flat h6 {
+.m-block.m-flat h3, .m-block.m-flat h4, .m-block.m-flat h5, .m-block.m-flat h6 {
   color: #000000;
 }
 .m-block.m-default h3 a:hover, .m-block.m-default h3 a:focus, .m-block.m-default h3 a:active,
@@ -1481,19 +1509,24 @@ table.m-table tr.m-dim td a:active, table.m-table td.m-dim a:active,
 table.m-table tr.m-dim th a:active, table.m-table th.m-dim a:active {
   color: #949494;
 }
-figure.m-figure.m-default:before { border-color: #fbf0ec; }
+figure.m-figure.m-default::before { border-color: #fbf0ec; }
 figure.m-figure.m-default figcaption { color: #000000; }
-figure.m-figure.m-primary:before { border-color: #ef9069; }
+figure.m-figure.m-primary::before { border-color: #ef9069; }
 figure.m-figure.m-primary figcaption { color: #cb4b16; }
-figure.m-figure.m-success:before { border-color: #4dd376; }
+figure.m-figure.m-primary figcaption .m-figure-description { color: #000000; }
+figure.m-figure.m-success::before { border-color: #4dd376; }
 figure.m-figure.m-success figcaption { color: #31c25d; }
-figure.m-figure.m-warning:before { border-color: #d1d34d; }
+figure.m-figure.m-success figcaption .m-figure-description { color: #000000; }
+figure.m-figure.m-warning::before { border-color: #d1d34d; }
 figure.m-figure.m-warning figcaption { color: #c7cf2f; }
-figure.m-figure.m-danger:before { border-color: #e23e3e; }
+figure.m-figure.m-warning figcaption .m-figure-description { color: #000000; }
+figure.m-figure.m-danger::before { border-color: #e23e3e; }
 figure.m-figure.m-danger figcaption { color: #f60000; }
-figure.m-figure.m-info:before { border-color: #4c93d3; }
+figure.m-figure.m-danger figcaption .m-figure-description { color: #000000; }
+figure.m-figure.m-info::before { border-color: #4c93d3; }
 figure.m-figure.m-info figcaption { color: #2e7dc5; }
-figure.m-figure.m-dim:before { border-color: #f1f1f1; }
+figure.m-figure.m-info figcaption .m-figure-description { color: #000000; }
+figure.m-figure.m-dim::before { border-color: #f1f1f1; }
 figure.m-figure.m-dim { color: #bdbdbd; }
 figure.m-figure.m-dim a { color: #c0c0c0; }
 figure.m-figure.m-dim a:hover, figure.m-figure.m-dim a:focus, figure.m-figure.m-dim a:active {
@@ -1507,11 +1540,13 @@ div.m-plot svg .m-bar.m-default,
 .m-graph g.m-node:not(.m-flat) polygon,
 .m-graph g.m-edge text,
 .m-graph g.m-node.m-flat text,
+.m-graph g.m-cluster text,
 .m-graph.m-default g.m-edge polygon,
 .m-graph.m-default g.m-node:not(.m-flat) ellipse,
 .m-graph.m-default g.m-node:not(.m-flat) polygon,
 .m-graph.m-default g.m-edge text,
-.m-graph.m-default g.m-node.m-flat text {
+.m-graph.m-default g.m-node.m-flat text,
+.m-graph.m-default g.m-cluster text {
   fill: #000000;
 }
 .m-graph g.m-edge polygon,
@@ -1519,11 +1554,13 @@ div.m-plot svg .m-bar.m-default,
 .m-graph g.m-node ellipse,
 .m-graph g.m-node polygon,
 .m-graph g.m-node polyline,
+.m-graph g.m-cluster polygon,
 .m-graph.m-default g.m-edge polygon,
 .m-graph.m-default g.m-edge path,
 .m-graph.m-default g.m-node ellipse,
 .m-graph.m-default g.m-node polygon,
-.m-graph.m-default g.m-node polyline {
+.m-graph.m-default g.m-node polyline,
+.m-graph.m-default g.m-cluster polygon {
   stroke: #000000;
 }
 .m-math.m-primary, .m-math g.m-primary, .m-math rect.m-primary,
@@ -1532,14 +1569,16 @@ div.m-plot svg .m-bar.m-primary,
 .m-graph.m-primary g.m-node:not(.m-flat) ellipse,
 .m-graph.m-primary g.m-node:not(.m-flat) polygon,
 .m-graph.m-primary g.m-edge text,
-.m-graph.m-primary g.m-node.m-flat text {
+.m-graph.m-primary g.m-node.m-flat text,
+.m-graph.m-primary g.m-cluster text {
   fill: #cb4b16;
 }
 .m-graph.m-primary g.m-edge polygon,
 .m-graph.m-primary g.m-edge path,
 .m-graph.m-primary g.m-node ellipse,
 .m-graph.m-primary g.m-node polygon,
-.m-graph.m-primary g.m-node polyline {
+.m-graph.m-primary g.m-node polyline,
+.m-graph.m-primary g.m-cluster polygon {
   stroke: #cb4b16;
 }
 .m-math.m-success, .m-math g.m-success, .m-math rect.m-success,
@@ -1548,14 +1587,16 @@ div.m-plot svg .m-bar.m-success,
 .m-graph.m-success g.m-node:not(.m-flat) ellipse,
 .m-graph.m-success g.m-node:not(.m-flat) polygon,
 .m-graph.m-success g.m-edge text,
-.m-graph.m-success g.m-node.m-flat text {
+.m-graph.m-success g.m-node.m-flat text,
+.m-graph.m-success g.m-cluster text {
   fill: #31c25d;
 }
 .m-graph.m-success g.m-edge polygon,
 .m-graph.m-success g.m-edge path,
 .m-graph.m-success g.m-node ellipse,
 .m-graph.m-success g.m-node polygon,
-.m-graph.m-success g.m-node polyline {
+.m-graph.m-success g.m-node polyline,
+.m-graph.m-success g.m-cluster polygon {
   stroke: #31c25d;
 }
 .m-math.m-warning, .m-math g.m-warning, .m-math rect.m-warning,
@@ -1564,14 +1605,16 @@ div.m-plot svg .m-bar.m-warning,
 .m-graph.m-warning g.m-node:not(.m-flat) ellipse,
 .m-graph.m-warning g.m-node:not(.m-flat) polygon,
 .m-graph.m-warning g.m-edge text,
-.m-graph.m-warning g.m-node.m-flat text {
+.m-graph.m-warning g.m-node.m-flat text,
+.m-graph.m-warning g.m-cluster text {
   fill: #c7cf2f;
 }
 .m-graph.m-warning g.m-edge polygon,
 .m-graph.m-warning g.m-edge path,
 .m-graph.m-warning g.m-node ellipse,
 .m-graph.m-warning g.m-node polygon,
-.m-graph.m-warning g.m-node polyline {
+.m-graph.m-warning g.m-node polyline,
+.m-graph.m-warning g.m-cluster polygon {
   stroke: #c7cf2f;
 }
 .m-math.m-danger, .m-math g.m-danger, .m-math rect.m-danger,
@@ -1580,14 +1623,16 @@ div.m-plot svg .m-bar.m-danger,
 .m-graph.m-danger g.m-node:not(.m-flat) ellipse,
 .m-graph.m-danger g.m-node:not(.m-flat) polygon,
 .m-graph.m-danger g.m-edge text,
-.m-graph.m-danger g.m-node.m-flat text {
+.m-graph.m-danger g.m-node.m-flat text,
+.m-graph.m-danger g.m-cluster text {
   fill: #f60000;
 }
 .m-graph.m-danger g.m-edge polygon,
 .m-graph.m-danger g.m-edge path,
 .m-graph.m-danger g.m-node ellipse,
 .m-graph.m-danger g.m-node polygon,
-.m-graph.m-danger g.m-node polyline {
+.m-graph.m-danger g.m-node polyline,
+.m-graph.m-danger g.m-cluster polygon {
   stroke: #f60000;
 }
 .m-math.m-info, .m-math g.m-info, .m-math rect.m-info,
@@ -1596,14 +1641,16 @@ div.m-plot svg .m-bar.m-info,
 .m-graph.m-info g.m-node:not(.m-flat) ellipse,
 .m-graph.m-info g.m-node:not(.m-flat) polygon,
 .m-graph.m-info g.m-edge text,
-.m-graph.m-info g.m-node.m-flat text {
+.m-graph.m-info g.m-node.m-flat text,
+.m-graph.m-info g.m-cluster text {
   fill: #2e7dc5;
 }
 .m-graph.m-info g.m-edge polygon,
 .m-graph.m-info g.m-edge path,
 .m-graph.m-info g.m-node ellipse,
 .m-graph.m-info g.m-node polygon,
-.m-graph.m-info g.m-node polyline {
+.m-graph.m-info g.m-node polyline,
+.m-graph.m-info g.m-cluster polygon {
   stroke: #2e7dc5;
 }
 .m-math.m-dim, .m-math g.m-dim, .m-math rect.m-dim,
@@ -1612,112 +1659,128 @@ div.m-plot svg .m-bar.m-dim,
 .m-graph.m-dim g.m-node:not(.m-flat) ellipse,
 .m-graph.m-dim g.m-node:not(.m-flat) polygon,
 .m-graph.m-dim g.m-edge text,
-.m-graph.m-dim g.m-node.m-flat text {
+.m-graph.m-dim g.m-node.m-flat text,
+.m-graph.m-dim g.m-cluster text {
   fill: #bdbdbd;
 }
 .m-graph.m-dim g.m-edge polygon,
 .m-graph.m-dim g.m-edge path,
 .m-graph.m-dim g.m-node ellipse,
 .m-graph.m-dim g.m-node polygon,
-.m-graph.m-dim g.m-node polyline {
+.m-graph.m-dim g.m-node polyline,
+.m-graph.m-dim g.m-cluster polygon {
   stroke: #bdbdbd;
 }
 .m-graph g.m-edge.m-default polygon,
 .m-graph g.m-node.m-default:not(.m-flat) ellipse,
 .m-graph g.m-node.m-default:not(.m-flat) polygon,
 .m-graph g.m-edge.m-default text,
-.m-graph g.m-node.m-default.m-flat text {
+.m-graph g.m-node.m-default.m-flat text,
+.m-graph g.m-cluster.m-default text {
   fill: #000000;
 }
 .m-graph g.m-edge.m-default polygon,
 .m-graph g.m-edge.m-default path,
 .m-graph g.m-node.m-default ellipse,
 .m-graph g.m-node.m-default polygon,
-.m-graph g.m-node.m-default polyline {
+.m-graph g.m-node.m-default polyline,
+.m-graph g.m-cluster.m-default polygon {
   stroke: #000000;
 }
 .m-graph g.m-edge.m-primary polygon,
 .m-graph g.m-node.m-primary:not(.m-flat) ellipse,
 .m-graph g.m-node.m-primary:not(.m-flat) polygon,
 .m-graph g.m-edge.m-primary text,
-.m-graph g.m-node.m-primary.m-flat text {
+.m-graph g.m-node.m-primary.m-flat text,
+.m-graph g.m-cluster.m-primary text {
   fill: #cb4b16;
 }
 .m-graph g.m-edge.m-primary polygon,
 .m-graph g.m-edge.m-primary path,
 .m-graph g.m-node.m-primary ellipse,
 .m-graph g.m-node.m-primary polygon,
-.m-graph g.m-node.m-primary polyline {
+.m-graph g.m-node.m-primary polyline,
+.m-graph g.m-cluster.m-primary polygon {
   stroke: #cb4b16;
 }
 .m-graph g.m-edge.m-success polygon,
 .m-graph g.m-node.m-success:not(.m-flat) ellipse,
 .m-graph g.m-node.m-success:not(.m-flat) polygon,
 .m-graph g.m-edge.m-success text,
-.m-graph g.m-node.m-success.m-flat text {
+.m-graph g.m-node.m-success.m-flat text,
+.m-graph g.m-cluster.m-success text {
   fill: #31c25d;
 }
 .m-graph g.m-edge.m-success polygon,
 .m-graph g.m-edge.m-success path,
 .m-graph g.m-node.m-success ellipse,
 .m-graph g.m-node.m-success polygon,
-.m-graph g.m-node.m-success polyline {
+.m-graph g.m-node.m-success polyline,
+.m-graph g.m-cluster.m-success polygon {
   stroke: #31c25d;
 }
 .m-graph g.m-edge.m-warning polygon,
 .m-graph g.m-node.m-warning:not(.m-flat) ellipse,
 .m-graph g.m-node.m-warning:not(.m-flat) polygon,
 .m-graph g.m-edge.m-warning text,
-.m-graph g.m-node.m-warning.m-flat text {
+.m-graph g.m-node.m-warning.m-flat text,
+.m-graph g.m-cluster.m-warning text {
   fill: #c7cf2f;
 }
 .m-graph g.m-edge.m-warning polygon,
 .m-graph g.m-edge.m-warning path,
 .m-graph g.m-node.m-warning ellipse,
 .m-graph g.m-node.m-warning polygon,
-.m-graph g.m-node.m-warning polyline {
+.m-graph g.m-node.m-warning polyline,
+.m-graph g.m-cluster.m-warning polygon {
   stroke: #c7cf2f;
 }
 .m-graph g.m-edge.m-danger polygon,
 .m-graph g.m-node.m-danger:not(.m-flat) ellipse,
 .m-graph g.m-node.m-danger:not(.m-flat) polygon,
 .m-graph g.m-edge.m-danger text,
-.m-graph g.m-node.m-danger.m-flat text {
+.m-graph g.m-node.m-danger.m-flat text,
+.m-graph g.m-cluster.m-danger text {
   fill: #f60000;
 }
 .m-graph g.m-edge.m-danger polygon,
 .m-graph g.m-edge.m-danger path,
 .m-graph g.m-node.m-danger ellipse,
 .m-graph g.m-node.m-danger polygon,
-.m-graph g.m-node.m-danger polyline {
+.m-graph g.m-node.m-danger polyline,
+.m-graph g.m-cluster.m-danger polygon {
   stroke: #f60000;
 }
 .m-graph g.m-edge.m-info polygon,
 .m-graph g.m-node.m-info:not(.m-flat) ellipse,
 .m-graph g.m-node.m-info:not(.m-flat) polygon,
 .m-graph g.m-edge.m-info text,
-.m-graph g.m-node.m-info.m-flat text {
+.m-graph g.m-node.m-info.m-flat text,
+.m-graph g.m-cluster.m-info text {
   fill: #2e7dc5;
 }
 .m-graph g.m-edge.m-info polygon,
 .m-graph g.m-edge.m-info path,
 .m-graph g.m-node.m-info ellipse,
 .m-graph g.m-node.m-info polygon,
-.m-graph g.m-node.m-info polyline {
+.m-graph g.m-node.m-info polyline,
+.m-graph g.m-cluster.m-info polygon {
   stroke: #2e7dc5;
 }
 .m-graph g.m-edge.m-dim polygon,
 .m-graph g.m-node.m-dim:not(.m-flat) ellipse,
 .m-graph g.m-node.m-dim:not(.m-flat) polygon,
 .m-graph g.m-edge.m-dim text,
-.m-graph g.m-node.m-dim.m-flat text {
+.m-graph g.m-node.m-dim.m-flat text,
+.m-graph g.m-cluster.m-dim text {
   fill: #bdbdbd;
 }
 .m-graph g.m-edge.m-dim polygon,
 .m-graph g.m-edge.m-dim path,
 .m-graph g.m-node.m-dim ellipse,
 .m-graph g.m-node.m-dim polygon,
-.m-graph g.m-node.m-dim polyline {
+.m-graph g.m-node.m-dim polyline,
+.m-graph g.m-cluster.m-dim polygon {
   stroke: #bdbdbd;
 }
 p, ul, ol, dl, blockquote, pre, .m-code-figure, .m-console-figure, hr, .m-note,
@@ -1975,24 +2038,41 @@ html:not(.m-presenter) .m-container { width: 100%; }
 }
 
 .m-console .hll { background-color: #ffffcc }
-.m-console .g-AnsiBlack { color: #000000 }
-.m-console .g-AnsiBlue { color: #3f3fd1 }
-.m-console .g-AnsiBrightBlack { color: #686868; font-weight: bold }
-.m-console .g-AnsiBrightBlue { color: #5454ff; font-weight: bold }
-.m-console .g-AnsiBrightCyan { color: #54ffff; font-weight: bold }
+.m-console .g-AnsiBackgroundBlack { background-color: #232627 }
+.m-console .g-AnsiBackgroundBlue { background-color: #1d99f3 }
+.m-console .g-AnsiBackgroundBrightBlack { background-color: #7f8c8d }
+.m-console .g-AnsiBackgroundBrightBlue { background-color: #3daee9 }
+.m-console .g-AnsiBackgroundBrightCyan { background-color: #16a085 }
+.m-console .g-AnsiBackgroundBrightGreen { background-color: #1cdc9a }
+.m-console .g-AnsiBackgroundBrightMagenta { background-color: #8e44ad }
+.m-console .g-AnsiBackgroundBrightRed { background-color: #c0392b }
+.m-console .g-AnsiBackgroundBrightWhite { background-color: #ffffff }
+.m-console .g-AnsiBackgroundBrightYellow { background-color: #fdbc4b }
+.m-console .g-AnsiBackgroundCyan { background-color: #1abc9c }
+.m-console .g-AnsiBackgroundGreen { background-color: #11d116 }
+.m-console .g-AnsiBackgroundMagenta { background-color: #9b59b6 }
+.m-console .g-AnsiBackgroundRed { background-color: #ed1515 }
+.m-console .g-AnsiBackgroundWhite { background-color: #fcfcfc }
+.m-console .g-AnsiBackgroundYellow { background-color: #f67400 }
+.m-console .g-AnsiBlack { color: #232627 }
+.m-console .g-AnsiBlue { color: #1d99f3 }
+.m-console .g-AnsiBrightBlack { color: #7f8c8d; font-weight: bold }
+.m-console .g-AnsiBrightBlue { color: #3daee9; font-weight: bold }
+.m-console .g-AnsiBrightCyan { color: #16a085; font-weight: bold }
 .m-console .g-AnsiBrightDefault { color: #ffffff; font-weight: bold }
-.m-console .g-AnsiBrightGreen { color: #54ff54; font-weight: bold }
-.m-console .g-AnsiBrightMagenta { color: #ff54ff; font-weight: bold }
-.m-console .g-AnsiBrightRed { color: #ff5454; font-weight: bold }
+.m-console .g-AnsiBrightGreen { color: #1cdc9a; font-weight: bold }
+.m-console .g-AnsiBrightInvertedDefault { color: #1a1c1d; font-weight: bold }
+.m-console .g-AnsiBrightMagenta { color: #8e44ad; font-weight: bold }
+.m-console .g-AnsiBrightRed { color: #c0392b; font-weight: bold }
 .m-console .g-AnsiBrightWhite { color: #ffffff; font-weight: bold }
-.m-console .g-AnsiBrightYellow { color: #ffff54; font-weight: bold }
-.m-console .g-AnsiCyan { color: #18b2b2 }
-.m-console .g-AnsiDefault { color: #b2b2b2 }
-.m-console .g-AnsiGreen { color: #18b218 }
-.m-console .g-AnsiMagenta { color: #b218b2 }
-.m-console .g-AnsiRed { color: #b21818 }
-.m-console .g-AnsiWhite { color: #b2b2b2 }
-.m-console .g-AnsiYellow { color: #b26818 }
-.m-console .go { color: #b2b2b2 }
-.m-console .gp { color: #54ffff; font-weight: bold }
-.m-console .w { color: #b2b2b2 }
+.m-console .g-AnsiBrightYellow { color: #fdbc4b; font-weight: bold }
+.m-console .g-AnsiCyan { color: #1abc9c }
+.m-console .g-AnsiGreen { color: #11d116 }
+.m-console .g-AnsiInvertedDefault { color: #1a1c1d }
+.m-console .g-AnsiMagenta { color: #9b59b6 }
+.m-console .g-AnsiRed { color: #ed1515 }
+.m-console .g-AnsiWhite { color: #fcfcfc }
+.m-console .g-AnsiYellow { color: #f67400 }
+.m-console .go { color: #fcfcfc }
+.m-console .gp { color: #16a085; font-weight: bold }
+.m-console .w { color: #fcfcfc }

--- a/css/m-light-presentation.css
+++ b/css/m-light-presentation.css
@@ -1,0 +1,31 @@
+/*
+    This file is part of m.css.
+
+    Copyright © 2017, 2018 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+@import url('m-theme-light.css');
+@import url('m-grid.css');
+@import url('m-components.css');
+@import url('m-presentation.css');
+@import url('pygments-console.css');
+
+/* kate: indent-width 2; */

--- a/css/m-presentation.css
+++ b/css/m-presentation.css
@@ -1,0 +1,307 @@
+/*
+    This file is part of m.css.
+
+    Copyright © 2017, 2018 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/* Preserve the same relative sizes and spacing independently on screen size.
+   Background color is handled by the slides themselves, reset it so the
+   presenter view has clearly separated slide view on white background. */
+html {
+  font-size: 2.49vw; /* 2.5 makes scrollbars on 1080p :/ */
+  background-color: transparent;
+}
+
+/* article { margin: -1rem; } */ /* TODO: or leave it? it breaks print in presenter mode because there's no m-nopad applied on col */
+article > aside, article > section {
+  height: 100vh;
+  padding: 1rem;
+}
+article > aside {
+  background-color: var(--header-background-color);
+}
+article > aside > h1 {
+  font-size: 4rem;
+  padding-top: 2rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-bottom: 2rem;
+}
+article > section {
+  position: relative; /* TODO remove */
+/*   overflow: hidden; */ /* TODO: it should be possible to view the slides
+  on a phone screen, so can't do this */
+  background-color: var(--background-color);
+}
+article > section.m-presentation-cover {
+  background-size: cover;
+  background-color: var(--header-background-color);
+  background-position: center center;
+  background-repeat: no-repeat;
+}
+/* h1, if present, covers the whole slide with a darker color. h2 goes over it
+   using a negative margin. Can't use absolute positioning as that breaks
+   print. */
+article > section > h1 {
+  margin: -1rem;
+  padding-top: 7rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  height: 100vh;
+  font-size: 4rem;
+}
+/* So the user doesn't have to specify the .m-presentation-cover class
+   explicitly every time */
+article > section:not(.m-presentation-cover) > h1 {
+  background-color: var(--header-background-color);
+}
+article > section.m-presentation-cover > h1,
+article > section.m-presentation-cover > h2 {
+  color: #ffffff;
+}
+article > section.m-presentation-cover.m-inverted > h1,
+article > section.m-presentation-cover.m-inverted > h2 {
+  color: #000000;
+}
+article > section > h1 + h2 {
+  margin-top: -100vh;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  padding-top: 13rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  font-size: 2rem;
+}
+article > section > h2:first-child {
+  color: var(--article-heading-color);
+  line-height: 3.5rem;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  margin-top: -1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  margin-bottom: 1rem;
+  background-color: var(--header-background-color);
+}
+article > section.m-presentation-background > h2:first-child {
+  background-color: var(--header-background-color-jumbo);
+}
+article > section > nav {
+  font-size: 85.4%; /* Equivalent to .m-small */
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  padding-bottom: 1.0rem;
+  padding-right: 0.5rem;
+}
+article > section > nav > a {
+  text-decoration: var(--link-decoration-nav);
+  display: inline-block;
+  width: 1.5rem;
+}
+article > section > nav > a:link, article > section > nav > a:visited {
+  color: var(--dim-link-color);
+}
+article > section > nav > a:hover, article > section > nav > a:active {
+  color: var(--dim-link-active-color);
+}
+article > section > nav > a.m-presentation-cover {
+  text-align: center;
+  width: 2.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+article > section > nav > a.m-presentation-prev { text-align: right; }
+article > section > nav > a.m-presentation-prev::before { content: '«'; }
+article > section > nav > a.m-presentation-next { text-align: left; }
+article > section > nav > a.m-presentation-next::before { content: '»'; }
+
+/* By default hide everything except the actual slideshow content */
+article > section > aside.m-presenter {
+  display: none;
+}
+
+/* Screen-specific style */
+@media screen {
+  /* Show the first slide or the boot menu when not in presenter mode. It gets
+     covered by any other slide after. */
+  html:not(.m-presenter) article > section:first-child {
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    z-index: -1;
+    overflow: hidden;
+  }
+
+  /* Show only the slide that is currently active. Another option would be to
+     make overflow hidden and just jump to section IDs by changing URL hash.
+     But sometimes we might want to scroll (unusual browser window aspect
+     ratios) and the presenter mode won't work very well. */
+  article > section { display: none; }
+  article > section:target { display: block; }
+}
+
+/* Don't limit the container width when in presentation mode or in print */
+html:not(.m-presenter) .m-container { width: 100%; }
+@media print { .m-container { width: 100%; } }
+
+/* Print style. Oh well, the support... */
+@media print {
+  /* Hide boot screen */
+  article > aside { display: none; }
+
+  /* Hide navigation, it has no use in a PDF */
+  article > section > nav { display: none; }
+
+  /* Preserve background color. WebKit-only, color-adjust: exact; *should* work
+     in Firefox, but affects only background color, font stays black which is
+     nowhere near usable. Users should explicitly check the "Preserve
+     background colors" option when printing. */
+  body { -webkit-print-color-adjust: exact; }
+
+  /* Otherwise Firefox would print one page more. 99.999999vh is one 9 too
+     much, 100vh also doesn't work. */
+  article > section:last-child { height: 99.99999vh; }
+
+  /* Every slide on its own page. Firefox would insert first blank page if I
+     would not exclude the first here. */
+  article > section:not(:first-of-type) { page-break-before: always; }
+
+  /* Page setup. Size works only on Chrome, on Firefox you need to add a new
+     size manually. */
+  @page {
+    margin: 0;
+    size: 297mm 167mm; /* 16:9 to fit on an A4 */
+  }
+}
+
+/* Presenter mode specifics. At the moment it's not possible to print presenter
+   mode because CSS @page can't be affected with any classes or IDs. */
+@media screen {
+  /*
+      Preserve font size for the slides the same as in slideshow mode. The
+      container has 1rem padding on sizes, need to account for that as well.
+
+      font_size = 0.025*content_width = 0.025*(container_width - 2*font_size)
+      font_size = 0.0238095*container_width
+  */
+  html.m-presenter { font-size: 2.381vw; }
+
+  /* TODO: with 1920x1080 there are scrollbars :/ */
+
+  @media screen and (min-width: 576px) {
+    html.m-presenter { font-size: 13.3333px; } /* 2.381% of 560px */
+  }
+  @media screen and (min-width: 768px) {
+    html.m-presenter { font-size: 14.8809px; } /* 2.381% of 10/12 of 750px */
+  }
+  @media screen and (min-width: 992px) {
+    /* Here the presentation is displayed in the center 10 columns, adjusting
+       font size appropriately (would be 24px otherwise) */
+    html.m-presenter { font-size: 19.0476px; } /* 2.381% of 10/12 of 960px */
+  }
+
+  /* TODO: <section> needs to start from top, otherwise going to a particular
+     #id with long presenter notes will scroll down UGLILY */
+
+  /* TODO: presenter notes should have padding on bottom */
+
+  /* TODO: unconditionally show the first slide in presenter mode, even if
+     there is the aside first */
+
+  html.m-presenter body {
+    overflow-y: scroll;
+  }
+
+  /* In the presenter view <article> is a container maintaining aspect ratio,
+     <section> fills it with 100% height (instead of 100vh) and everything
+     positions absolutely instead of having negative margins. */
+  html.m-presenter article {
+    position: relative;
+    margin: 0;
+    padding-top: 56.25%; /* 16:9 */
+    background-color: var(--background-color);
+  }
+  /* Show the boot screen in presenter mode */
+/*  html.m-presenter article > aside {
+    display: block;
+  }*/
+  html.m-presenter article > aside,
+  html.m-presenter article > section {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+    /*overflow: hidden; /* TODO ugh this hides presenter notes ... also, have on the normal view as well (?) */
+  }
+  html.m-presenter article > *:first-child {
+/*    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    z-index: -1;
+    overflow: hidden;*/
+  }
+  html.m-presenter article > section > h1 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+    margin: 0;
+  }
+  html.m-presenter article > section > h1 + h2 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    margin: 0;
+  }
+  /* The presenter notes are stuck right below the <section> element. */
+  html.m-presenter article > aside > aside.m-presenter,
+  html.m-presenter article > section > aside.m-presenter {
+    display: block;
+    position: absolute;
+    top: 0;
+    margin-top: 56.25%; /* 16:9 */
+    color: #000000;
+    font-size: var(--font-size);
+  }
+  html.m-presenter article > aside > aside.m-presenter {
+    padding-top: 1rem;
+  }
+  html.m-presenter article > section > aside.m-presenter {
+    padding-top: 3rem;
+  }
+  html.m-presenter article > section > aside.m-presenter code,
+  html.m-presenter article > section > aside.m-presenter pre {
+    color: #000000;
+    background-color: transparent;
+    font-size: var(--code-font-size);
+  }
+}
+
+/* kate: indent-width 2; */

--- a/css/postprocess.sh
+++ b/css/postprocess.sh
@@ -1,7 +1,9 @@
 ./postprocess.py m-dark.css
+./postprocess.py m-dark-presentation.css
 ./postprocess.py m-dark.css m-documentation.css -o m-dark+documentation.compiled.css
 ./postprocess.py m-dark.css m-theme-dark.css m-documentation.css --no-import -o m-dark.documentation.compiled.css
 
 ./postprocess.py m-light.css
+./postprocess.py m-light-presentation.css
 ./postprocess.py m-light.css m-documentation.css -o m-light+documentation.compiled.css
 ./postprocess.py m-light.css m-theme-light.css m-documentation.css --no-import -o m-light.documentation.compiled.css

--- a/doc/css.rst
+++ b/doc/css.rst
@@ -67,6 +67,15 @@ terminal output) on your website, there's also a builtin style for
 -   :gh:`pygments-console.css <mosra/m.css$master/css/pygments-console.css>`,
     generated from :gh:`pygments-console.py <mosra/m.css$master/css/pygments-console.py>`
 
+For designing presentations instead of pages and articles, the following files
+replace the ``m-layout.css`` and ``m-dark.css`` / ``m-light.css`` entry points:
+
+-   :gh:`m-presentation.css <mosra/m.css$master/css/m-presentation.css>`
+-   :gh:`m-dark-presentation.css <mosra/m.css$master/css/m-dark-presentation.css>`
+    or :gh:`m-light-presentation.css <mosra/m.css$master/css/m-light-presentation.css>`
+    that :css:`@import` all relevant files for a convenient single-line
+    referencing
+
 Once you have the files, reference them from your HTML markup. The top-level
 ``m-dark.css`` / ``m-light.css`` file includes the others via a CSS
 :css:`@import` statement, so you don't need to link all of them. The dark theme
@@ -106,6 +115,17 @@ to include a proper :html:`<meta>` tag. The HTML5 DOCTYPE is also required.
     -   :gh:`m-light.compiled.css <mosra/m.css$master/css/m-light.compiled.css>`
         (:filesize:`{static}/../css/m-light.compiled.css`,
         :filesize-gz:`{static}/../css/m-light.compiled.css` compressed)
+
+    Or, the presentation style:
+
+    -   :gh:`m-dark-presentation.compiled.css <mosra/m.css$master/css/m-dark-presentation.compiled.css>`
+        (:filesize:`{filename}/../css/m-dark-presentation.compiled.css`,
+        :filesize-gz:`{filename}/../css/m-dark-presentation.compiled.css`
+        compressed)
+    -   :gh:`m-light-presentation.compiled.css <mosra/m.css$master/css/m-light-presentation.compiled.css>`
+        (:filesize:`{filename}/../css/m-light-presentation.compiled.css`,
+        :filesize-gz:`{filename}/../css/m-light-presentation.compiled.css`
+        compressed)
 
     I recommend using the original files for development and switching to the
     compiled versions when publishing the website.
@@ -152,6 +172,12 @@ image grid.
 In ``m-layout.css`` there's a styling for the whole page including navigation
 --- header and footer, section headings, article styling with sidebar, tag
 cloud, active section highlighting and more.
+
+`Presentation » <{filename}/css/presentation.rst>`_
+===================================================
+
+The ``m-presentation.css`` file contains styling for presentation layouts,
+together with presenter view and PDF printing support.
 
 `Themes » <{filename}/css/themes.rst>`_
 =======================================

--- a/doc/css/page-layout.rst
+++ b/doc/css/page-layout.rst
@@ -31,7 +31,7 @@ Page layout
     .. note-dim::
         :class: m-text-center
 
-        `« Components <{filename}/css/components.rst>`_ | `CSS <{filename}/css.rst>`_ | `Themes » <{filename}/css/themes.rst>`_
+        `« Components <{filename}/css/components.rst>`_ | `CSS <{filename}/css.rst>`_ | `Presentation » <{filename}/css/presentation.rst>`_
 
 .. role:: raw-html(raw)
    :format: html

--- a/doc/css/presentation.rst
+++ b/doc/css/presentation.rst
@@ -1,0 +1,340 @@
+..
+    This file is part of m.css.
+
+    Copyright © 2017, 2018 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+..
+
+Presentation
+############
+
+:breadcrumb: {filename}/css.rst CSS
+:footer:
+    .. note-dim::
+        :class: m-text-center
+
+        `« Page layout <{filename}/css/page-layout.rst>`_ | `CSS <{filename}/css.rst>`_ | `Themes » <{filename}/css/themes.rst>`_
+
+.. |x| unicode:: U+00D7 .. nicer multiply sign
+
+The `m-presentation.css <{filename}/css.rst>`_ file allows you to easily reuse
+existing m.css features and components like math rendering or code highlighting
+to create presentations (slide decks, keynotes, ..., you name it) that match
+your website theme.
+
+.. note-success::
+
+    Check out the `m.css presentation generator <{filename}/presentation.rst>`_
+    --- a standalone Python script for creating presentations directly from
+    :abbr:`reST <reStructuredText>` sources using m.css components.
+
+.. contents::
+    :class: m-block m-default
+
+`Features`_
+===========
+
+-   Reuse all existing m.css components to create presentations
+-   Ability to show a "presenter view" with additional notes
+-   Print directly to PDF on supported browsers for maximal compatibility
+-   CSS-only with a possibility to implement extra features using JavaScript
+
+`Basic markup structure`_
+=========================
+
+A minimal markup structure is below, very similar to the one for ganeric
+`page layout <{filename}/css/page-layout.rst>`_ --- with :html:`<html lang="en">`
+and a :html:`<meta>` tag specifying the file encoding, which should be the
+first thing in :html:`<head>`. It's also important to specify that the site is
+responsive via the :html:`<meta name="viewport">` tag.
+
+The presentation style imposes some constraints on the layout grid --- in
+particular, for the presentation mode, the content should span all 12 rows of
+the `grid system <{filename}/css/grid.rst>`_. This is different from the
+presenter view that's `described below <#presenter-view>`_. Specifying
+:css:`.m-container-inflatable` will make it possible for components such as
+code blocks or images to make use of the whole screen width. If you don't like
+it, simply don't specify the class.
+
+.. code:: html
+
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <title>Presentation title</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <link rel="stylesheet" href="m-dark-presentation.css" />
+    </head>
+    <body>
+    <div class="m-container m-container-inflatable">
+      <div class="m-row">
+        <div class="m-col-l-12">
+          <article>
+            <section id="first">
+              <!-- here goes the first slide -->
+            </section>
+            <section id="second">
+              <!-- here goes the second slide -->
+            </section>
+            <!-- ... -->
+          </article>
+        </div>
+      </div>
+    </div>
+    </body>
+    </html>
+
+The :html:`<article>` contains actual contents of the presentation, with every
+:html:`<section>` being one slide. The ``id`` attribute is important, it's used
+to flip through the slides. Note that nested :html:`<section>`\ s are not
+possible.
+
+`Cover slides`_
+---------------
+
+Cover slides simply contain a :html:`<h1>` element and an optional subtitle in
+:html:`<h2>`. The :html:`<h1>` fills the slide with a darker background.
+
+.. code:: html
+
+    <section id="cover">
+      <h1>A presentation title</h1>
+      <h2>A presentation subtitle</h2>
+    </section>
+
+.. note-info::
+
+    See how a basic presentation `looks <{filename}/css/presentation/example.html>`_.
+
+`Content slides`_
+-----------------
+
+Putting :html:`<h2>` first into the :html:`<section>` makes it a content slide.
+After that, you can fill the rest with the usual m.css components, including
+various grid layouts. `See below <#content-scaling-and-aspect-ratio>`_ for
+general information about how the content responsiveness is handled.
+
+.. code:: html
+
+    <section id="overview">
+      <h2>Overview</h2>
+      <div class="m-row">
+        <div class="m-col-t-6">
+          <ul>
+            <li>A list</li>
+            <li>of things</li>
+            <li>to present</li>
+          </ul>
+        </div>
+        <div class="m-col-t-6">
+          <pre>some_code: {
+        // to show
+        as_part(of_the, slide);
+    }</pre>
+        </div>
+      </div>
+    </section>
+
+`"Boot screen"`_
+----------------
+
+Sometimes it's desirable to have some "boot screen" even before the first cover
+slide --- for example with organizer notes or a link to open a presenter view
+window. This can be done by addding an :html:`<aside>` element before all other
+:html:`<section>` elements. It gets a darker background and extra space for
+content after :html:`<h1>`. It doesn't require the ``id`` attribute as it's
+often not desired to flip back to the boot screen during a presentation --- but
+if you specify it, you'll be able to do that.
+
+.. code:: html
+    :class: m-inverted
+    :hl_lines: 2 3 4 5 6 7 8 9
+
+    <article>
+      <aside>
+        <h1>A presentation title</h1>
+        <ul>
+          <li>Power up the beam</li>
+          <li><a href="presenter/">Open presenter view</a></a>
+          <li>Have a glass of water</li>
+        </ul>
+      </aside>
+      <section id="cover">
+        ...
+
+The boot screen is also shown neither the `presenter view`_ nor included when
+`printing to a PDF`_.
+
+`Background images on cover slides`_
+------------------------------------
+
+Add :css:`.m-presentation-cover` CSS class together with a background image to
+a `cover slide <#cover-slides>`_. This will make the :html:`<h1>` /
+:html:`<h2>` headings fully white and the cover image will be scaled to cover
+the whole slide. If you have a bright background image, use the :css:`.m-inverted`
+CSS class to make the headings black.
+
+.. code:: html
+    :class: m-inverted
+    :hl_lines: 1 2
+
+    <section id="..." class="m-presentation-cover"
+        style="background-image: url('image.jpg')">
+      <h1>A presentation title</h1>
+      ...
+    </section>
+
+`Flipping through the content`_
+===============================
+
+Initially, the first :html:`<section>` (or :html:`<aside>`) contained in the
+:html:`<article>` element is displayed and all others are hidden. Flipping
+through the presentation is done by changing the hash part of page URL, for
+example going to ``#overview`` will show contents of the
+:html:`<section id="overview">` slide.
+
+To provide on-screen controls, add a :html:`<nav>` element with links to
+previous, next and cover slide at the end of every :html:`<section>` element:
+
+.. code:: html
+    :class: m-inverted
+    :hl_lines: 4 5 6 7 8
+
+    <section id="features">
+      <h2>Features</h2>
+      ...
+      <nav>
+        <a class="m-presentation-prev" href="#overview"></a>
+        <a class="m-presentation-cover" href="#cover">4 / 17</a>
+        <a class="m-presentation-next" href="#usage"></a>
+      </nav>
+    </section>
+
+The :html:`<nav>` element will be tucked to bottom right of the slide in a dim
+small font. The :css:`.m-presentation-prev` and :css:`.m-presentation-next`
+links will be filled with the « or » character by the style. It's possible to
+omit the center :css:`.m-presentation-cover` link. To preserve the alignment on
+the first and last slide but hide the inactive controls, simply replace given
+link with an empty :html:`<a></a>` placeholder. The navigation controls are
+shown in the `presenter view`_ but removed when `printing to a PDF`_.
+
+.. note-success::
+
+    The `m.css presentation framework <{filename}/presentation.rst>`_ is able
+    to generate the on-screen controls automatically, together with a tiny
+    JavaScript driver code that attaches to key / touch events for easier use.
+
+`Content scaling and aspect ratio`_
+===================================
+
+The content scales uniformly to fill 100% of window width and, as long as you
+stick to using responsive m.css components, the output should keep the same
+layout regardless on window size.
+
+Because the content keeps the same layout regardless of screen size, it's not
+desirable to use any responsive grid features of m.css --- in particular, if
+you want to split content into multiple columns, use the
+`"tiny" CSS classes <{filename}/css/grid.rst#detailed-grid-properties>`_
+(:css:`.m-col-t-*`, :css:`.m-push-t-*` etc.) unconditionally.
+
+.. note-info::
+
+    At the moment, the style is hardcoded to a 16:9 aspect ratio, which affects
+    presenter view and print page size.
+
+`Presenter view`_
+=================
+
+A common case is to have the presentation displayed on an external screen or a
+projector and at the same time have a "presenter view" with additional notes
+displayed on the main screen.
+
+The m.css presentation style allows to create a presenter view using the
+following markup. Important is adding the :css:`.m-presenter` class to the root
+:html:`<html>` element and limiting the contents to 10 columns on large screens
+using :css:`.m-col-l-10`. Then for every :html:`<section>` where you need to
+have additional presenter notes, add them to a new :html:`<aside>` element at
+the end.
+
+.. code:: html
+    :class: m-inverted
+    :hl_lines: 2 9 13 14 15
+
+    <!DOCTYPE html>
+    <html lang="en" class="m-presenter">
+    ...
+    <body>
+    <div class="m-container m-container-inflatable">
+      <div class="m-row">
+        <div class="m-col-l-10 m-push-m-1">
+          <article>
+            ...
+            <section id="features">
+              <h2>Features</h2>
+              ...
+              <aside class="m-presenter">
+                <!-- here go presenter notes -->
+              </aside>
+            </section>
+            ...
+          </article>
+        </div>
+      </div>
+    </div>
+    </body>
+    </html>
+
+The presenter view will display the slide content in a smaller area at the top,
+with presenter notes below. The view follows usual m.css responsiveness rules,
+so it can be tucked to a very narrow window for example, with the slide being
+scaled but notes keeping a fixed size.
+
+The presenter notes are displayed in a black font on a white background and
+aren't designed for advanced layouting capabilities apart from basic
+paragraphs, links and list items.
+
+.. note-success::
+
+    The `m.css presentation framework <{filename}/presentation.rst>`_ makes it
+    possible to have flipping through the slides synchronized between the
+    presentation and presenter view window.
+
+`Printing to a PDF`_
+====================
+
+It's possible to convert the presentation to a PDF simply by using browser's
+print functionality. At the moment, Chromium-based browsers are the only which
+respect CSS page size, borders and background/foreground colors.
+
+.. block-warning:: Printing with Firefox
+
+    Unfortunately at the moment Firefox doesn't respect CSS :css:`@page` size
+    and the Firefox-specific :css:`color-adjust: exact;` option works only
+    halfway, background colors are preserved but all fonts are turned black.
+
+    With some manual work, it's possible to print from Firefox as well. You
+    need to manually override page size to 16:9 aspect ratio (m.css uses
+    29.7\ |x|\ 16.7 mm), enable borderless print and toggle the "Print
+    background colors" to preserve both background color and font color.
+
+The printed version preserves only the slide content, hiding the "boot screen"
+or navigation controls, if any. At the moment, printing from the presenter view
+will print only the slide content, without presenter notes.

--- a/doc/css/presentation/test.html
+++ b/doc/css/presentation/test.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>A presentation</title>
+  <meta name="template" content="passthrough" />
+  <meta name="css" content="
+    /static/m-dark-presentation.css
+    https://fonts.googleapis.com/css?family=Source+Code+Pro:400,400i,600%7CSource+Sans+Pro:400,400i,600,600i&amp;subset=latin-ext
+    " />
+  <meta name="js" content="/static/presentation.js" />
+</head>
+<body>
+<div class="m-container m-container-inflatable">
+<div class="m-row">
+<div class="m-col-l-12">
+<article>
+  <section id="cover" class="m-presentation-cover" style="background-image: url('/static/cover.jpg')">
+    <h1>A presentation</h1>
+    <h2>with cover image</h2>
+    <nav>
+      <a href="#cover-inverted" class="m-presentation-next"></a>
+    </nav>
+    <aside class="m-presenter">
+      Presenter notes.
+    </aside>
+  </section>
+  <section id="cover-inverted" class="m-presentation-cover m-inverted" style="background-image: url('/static/ship.jpg')">
+    <h1>A presentation</h1>
+    <h2>with inverted cover image</h2>
+    <nav>
+      <a href="#cover" class="m-presentation-prev"></a>
+      <a href="#cover" class="m-presentation-cover">2 / 3</a>
+      <a href="#slide1" class="m-presentation-next"></a>
+    </nav>
+    <aside class="m-presenter">
+      Further presenter notes.
+    </aside>
+  </section>
+  <section id="slide1">
+    <h2>Slide one</h2>
+    <ul>
+      <li>Content</li>
+    </ul>
+    <nav>
+      <a href="#overview" class="m-presentation-prev"></a>
+      <a href="#cover" class="m-presentation-cover">3 / 3</a>
+      <a></a>
+    </nav>
+    <aside class="m-presenter">
+      More presenter notes.
+    </aside>
+  </section>
+</article>
+</div>
+</div>
+</div>
+</body>
+</html>
+<!-- kate: indent-width 2; -->

--- a/doc/css/presentation/test/boot-screen.html
+++ b/doc/css/presentation/test/boot-screen.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en"><!-- kate: indent-width 2; -->
+<head>
+  <title>A presentation</title>
+  <meta name="template" content="passthrough" />
+  <meta name="css" content="
+    /static/m-dark-presentation.css
+    https://fonts.googleapis.com/css?family=Source+Code+Pro:400,400i,600%7CSource+Sans+Pro:400,400i,600,600i&amp;subset=latin-ext
+    " />
+  <meta name="js" content="/static/presentation.js" />
+</head>
+<body>
+<div class="m-container m-container-inflatable">
+<div class="m-row">
+<div class="m-col-l-12">
+<article>
+  <aside>
+    <h1>A presentation title</h1>
+    <div class="m-row">
+      <div class="m-col-t-5 m-push-t-1">
+        <div class="m-button m-primary"><a href="#cover">
+          <div class="m-big">Start the presentation</div>
+          <div class="m-small">from the beginning</div>
+        </a></div>
+      </div>
+      <div class="m-col-t-5 m-push-t-1">
+        <div class="m-button m-success"><a href="{filename}/css/presentation/example-presenter.html#cover" onclick="return openPresenterView(this);">
+          <div class="m-big">Open presenter view</div>
+          <div class="m-small">in a new window</div>
+        </a></div>
+      </div>
+    </div>
+    <div class="m-text m-text-center m-small m-dim">Powered by <a href="http://mcss.mosra.cz">m.css</a>, copyright © <a href="http://mcss.mosra.cz">Vladimír Vondruš</a>, 2017&ndash;2018.</div>
+  </aside>
+  <section id="cover">
+    <h1>A presentation</h1>
+    <h2>With a boot screen</h2>
+    <aside class="m-presenter">
+      Presenter notes.
+    </aside>
+  </section>
+  <section id="slide0">
+    <h2>Slide zero</h2>
+    <ul>
+      <li>Content</li>
+    </ul>
+    <aside class="m-presenter">
+      Presenter notes.
+    </aside>
+  </section>
+  <section id="slide1">
+    <h2>Slide one</h2>
+    <ul>
+      <li>Content</li>
+    </ul>
+    <aside class="m-presenter">
+      More presenter notes.
+    </aside>
+  </section>
+  <section id="slide2">
+    <h1>Thank you!</h1>
+    <h2>huh this goes where exactly?</h2>
+  </section>
+</article>
+</div>
+</div>
+</div>
+</body>
+</html>

--- a/doc/css/presentation/test/presenter.html
+++ b/doc/css/presentation/test/presenter.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>A presentation</title>
+  <meta name="template" content="passthrough" />
+  <meta name="class" content="m-presenter" />
+  <meta name="css" content="
+    /static/m-dark-presentation.css
+    https://fonts.googleapis.com/css?family=Source+Code+Pro:400,400i,600%7CSource+Sans+Pro:400,400i,600,600i&amp;subset=latin-ext
+    " />
+  <meta name="js" content="/static/presentation.js" />
+</head>
+<body>
+<div class="m-container m-container-inflatable">
+<div class="m-row">
+<div class="m-col-l-10 m-push-l-1">
+<article>
+  <aside>
+    <h1>A presentation title</h1>
+    <p>This will not be displayed at all in the presenter view.</p>
+  </aside>
+  <section id="cover" class="m-presentation-cover" style="background-image: url('/static/cover.jpg')">
+    <h1>A presentation</h1>
+    <h2>A presentation subtitle</h2>
+    <nav>
+      <a href="#overview" class="m-presentation-next"></a>
+    </nav>
+    <aside class="m-presenter">
+      Presenter notes.
+    </aside>
+  </section>
+  <section id="overview">
+    <h2>Overview</h2>
+    <div class="m-row">
+      <div class="m-col-t-6">
+        <ul>
+          <li>A list</li>
+          <li>of things</li>
+          <li>to present</li>
+        </ul>
+      </div>
+      <div class="m-col-t-6">
+        <pre>some_code: {
+    // to show
+    as_part(of_the, slide);
+}</pre>
+      </div>
+    </div>
+    <nav>
+      <a href="#cover" class="m-presentation-prev"></a>
+      <a href="#cover" class="m-presentation-cover">2 / 3</a>
+      <a href="#slide1" class="m-presentation-next"></a>
+    </nav>
+    <aside class="m-presenter">
+      Presenter notes.
+    </aside>
+  </section>
+  <section id="slide1">
+    <h2>Slide one</h2>
+    <ul>
+      <li>Content</li>
+    </ul>
+    <nav>
+      <a href="#overview" class="m-presentation-prev"></a>
+      <a href="#cover" class="m-presentation-cover">3 / 3</a>
+      <a></a>
+    </nav>
+    <aside class="m-presenter">
+      More presenter notes.
+    </aside>
+  </section>
+</article>
+</div>
+</div>
+</div>
+</body>
+</html>
+<!-- kate: indent-width 2; -->

--- a/doc/css/themes.rst
+++ b/doc/css/themes.rst
@@ -31,7 +31,7 @@ Themes
     .. note-dim::
         :class: m-text-center
 
-        `« Page layout <{filename}/css/page-layout.rst>`_ | `CSS <{filename}/css.rst>`_
+        `« Presentation <{filename}/css/presentation.rst>`_ | `CSS <{filename}/css.rst>`_
 
 .. role:: css(code)
     :language: css

--- a/doc/presentation.rst
+++ b/doc/presentation.rst
@@ -1,0 +1,150 @@
+Presentation framework
+######################
+
+Create modern-looking presentations to be viewed in a browser or printed to a
+PDF directly from :abbr:`reST <reStructuredText>` sources, utilizing existing
+m.css components for easy-to-author content and lightweight output.
+
+.. button-success:: http://mcss.mosra.cz/presentation/example/
+
+    Live demo
+
+    a m.css showcase
+
+.. contents::
+    :class: m-block m-default
+
+`Basic usage`_
+==============
+
+The presentation generator is a single script that makes use of many existing
+m.css features, so the easiest way is to clone the whole repository:
+
+.. code:: sh
+
+    git clone git://github.com/mosra/m.css
+    cd m.css/presentation
+
+The script requires at least Python 3.4 and at minimal depends on
+`Docutils <http://docutils.sourceforge.net/>`_ for :abbr:`reST <reStructuredText>`
+parsing and `Jinja2 <http://jinja.pocoo.org/>`_ for templating. Further
+dependencies might be required if you enable particular plugins, `more on that
+below <#plugins>`_. You can install it via ``pip`` or your distribution package
+manager:
+
+.. code:: sh
+
+    # You may need sudo here
+    pip3 install docutils jinja2
+
+.. note-danger::
+
+    Similarly to the m.css `Pelican theme <{filename}/pelican/theme.rst>`_ and
+    `plugins <{filename}/plugins.rst>`_, at least Python 3.4 is required; some
+    plugins (such as the `math plugin <{filename}/plugins/math-and-code.rst#math>`_)
+    may need even newer versions. Python 2 is not supported.
+
+Now, with everything set up, let's write a minimal presentation and save it
+with a ``.rst`` extension:
+
+.. code:: rst
+
+    My presentation
+    ###############
+
+    Welcome
+    =======
+
+    Agenda:
+
+    1.  Show that simple things are simple
+    2.  And advanced things are not hard either
+
+    Is it that easy?
+    ================
+
+    Absolutely!
+
+        It's really *that* easy.
+
+        --- The presenter
+
+    And that's it
+    =============
+
+    Thank you!
+
+Now run the tool on your file and enable a server with auto-reload:
+
+.. code:: shell-session
+
+    $ ./present.py path/to/your/presentation.rst -rl
+    INFO:root:serving on http://localhost:8000 with autoreload ...
+    INFO:root:watching 1 paths
+
+The script will generate the output to an ``output/`` subdirectory next to
+your file and make it available at http://localhost:8000. When you open the URL
+in a browser, you can navigate through the slides using arrow keys, touch swipe
+or the on-screen controls.
+
+If you change anything in the file, the output will get automatically
+regenrated --- and any new files you reference, include or link to will get
+added to the watch list as well for a consistent experience. Seeing the updated
+presentation in your browser is then just one :label-default:`F5` away. If your
+browser is modern enough, you can also try printing out the content to a PDF
+for an even better reusability. See the
+`docs about PDF printing <{filename}/css/presentation.rst#printing-to-a-pdf>`_
+for more information.
+
+`Writing content`_
+==================
+
+The presentation sources are written in reStructuredText. If you don't know it
+already from other m.css features or e.g. Sphinx, here is a basic
+`overview of the syntax <{filename}/pelican/writing-content.rst>`_. The guide
+is written for the m.css Pelican theme, but most of it applies here as well.
+
+.. TODO: metadata: cover, bundle
+.. TODO: subtitles and section subtitles
+
+`Slide customization`_
+======================
+
+.. TODO: describe all these:
+
+.. code:: rst
+
+    :cover: image.jpg
+    :js:
+        EmscriptenApplication.js
+    :css:
+        showcase.css
+    :bundle:
+        build-emscripten-wasm/Application.js
+        build-emscripten-wasm/Application.wasm
+    :after:
+        .. raw:: html
+
+`"Boot screen"`_
+================
+
+`Presenter mode and presenter notes`_
+=====================================
+
+.. code:: rst
+
+    A presentation slide
+    ====================
+
+    -   Simple words
+    -   for the audience
+
+    .. presenter::
+
+        Additional details that are worth mentioning for this slide.
+
+`Configuration`_
+================
+
+`Command-line options`_
+=======================

--- a/pelican-theme/static/m-dark-presentation.css
+++ b/pelican-theme/static/m-dark-presentation.css
@@ -1,0 +1,1 @@
+../../css/m-dark-presentation.css

--- a/pelican-theme/static/m-light-presentation.css
+++ b/pelican-theme/static/m-light-presentation.css
@@ -1,0 +1,1 @@
+../../css/m-light-presentation.css

--- a/pelican-theme/static/m-presentation.css
+++ b/pelican-theme/static/m-presentation.css
@@ -1,0 +1,1 @@
+../../css/m-presentation.css

--- a/pelican-theme/static/presentation.js
+++ b/pelican-theme/static/presentation.js
@@ -1,0 +1,1 @@
+../../presentation/presentation.js

--- a/presentation/present.py
+++ b/presentation/present.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+
+#
+#   This file is part of m.css.
+#
+#   Copyright © 2017, 2018 Vladimír Vondruš <mosra@centrum.cz>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+import argparse
+import copy
+import docutils
+import docutils.transforms
+import http.server
+import inspect
+import importlib
+import jinja2
+import logging
+import multiprocessing
+import os
+import shutil
+import sys
+import time
+import urllib
+
+from importlib.machinery import SourceFileLoader
+from types import SimpleNamespace as Empty
+
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../plugins'))
+import m.htmlsanity
+
+from docutils.parsers import rst
+from docutils.parsers.rst import directives
+from docutils.parsers.rst.roles import set_classes
+from docutils import nodes
+
+class PresenterDirective(rst.Directive):
+    has_content = True
+    optional_arguments = 0
+
+    def run(self):
+        set_classes(self.options)
+
+        text = '\n'.join(self.content)
+        topic_node = nodes.topic(text, **self.options)
+        topic_node['classes'] += ['m-presenter']
+
+        self.state.nested_parse(self.content, self.content_offset,
+                                topic_node)
+        return [topic_node]
+
+default_templates = os.path.dirname(os.path.realpath(__file__))
+default_config = {
+    # INPUT deliberately omitted
+    'OUTPUT': 'output',
+    # Also configurable via --presenter on the command-line
+    'PRESENTER_VIEW': None,
+
+    'STYLESHEETS': [
+        'https://fonts.googleapis.com/css?family=Source+Code+Pro:400,400i,600%7CSource+Sans+Pro:400,400i,600,600i',
+        '../css/m-dark-presentation.compiled.css'],
+    'EXTRA_FILES': [],
+    'FORMATTED_METADATA': [],
+
+    'PLUGINS': [],
+    'PLUGIN_PATHS': [],
+}
+
+class SectionMetadata(docutils.transforms.Transform):
+    # Max Docutils priority is 990, be sure that this is applied at the very
+    # last
+    default_priority = 991
+
+    def __init__(self, document, startnode):
+        docutils.transforms.Transform.__init__(self, document, startnode=startnode)
+
+    def apply(self):
+        pyphen_for_lang = {}
+
+        # Go through all section-specific metadata and use them
+        for section in self.document.traverse(nodes.section):
+            field_list = section.first_child_matching_class(nodes.field_list)
+            if not field_list: continue
+
+            for field in section[field_list]:
+                if field[0][0] == 'background_color':
+                    if 'style' not in section: section['style'] = []
+                    section['style'] += ['background-color: {};'.format(field[1][0].astext())]
+                    section['classes'] += ['m-presentation-background']
+
+            section.remove(section[field_list]) # TODO: remove
+
+class PresentationHtmlTranslator(m.htmlsanity._SaneFieldBodyTranslator):
+    # Copied from .m.htmlsanity, plus making it possible to add arbitrary
+    # styles to sections
+    def visit_section(self, node):
+        atts = {}
+        if 'style' in node: atts['style'] = node['style']
+        self.section_level += 1
+        self.body.append(
+            self.starttag(node, 'section', **atts))
+
+    def depart_section(self, node):
+        self.section_level -= 1
+        self.body.append('</section>\n')
+
+    # Hide fields from the output
+    #def visit_field_body(self, node):
+        #pass
+    #def depart_field_body(self, node):
+        #pass
+
+class PresentationWriter(m.htmlsanity.SaneHtmlWriter):
+    def __init__(self):
+        m.htmlsanity.SaneHtmlWriter.__init__(self)
+
+        self.translator_class = PresentationHtmlTranslator
+
+    def get_transforms(self):
+        return m.htmlsanity.SaneHtmlWriter.get_transforms(self) + [SectionMetadata]
+
+class Presenter:
+    def __init__(self, templates, config):
+        self.config = config
+        self.hooks_pre_page = []
+        self.hooks_post_run = []
+
+        # Set up extra plugin paths. The one for m.css plugins was added above.
+        for path in config['PLUGIN_PATHS']:
+            if path not in sys.path: sys.path.append(os.path.join(os.path.dirname(config['INPUT']), path))
+
+        # Set up Jinja environment
+        self.env = jinja2.Environment(loader=jinja2.FileSystemLoader(templates),
+            trim_blocks=True, lstrip_blocks=True, enable_async=True)
+        def basename_or_url(path):
+            if urllib.parse.urlparse(path).netloc: return path
+            return os.path.basename(path)
+        self.env.filters['basename_or_url'] = basename_or_url
+
+        # Import plugins
+        for plugin in ['m.htmlsanity'] + config['PLUGINS']:
+            # The plugins expect INPUT as a directory, not a file
+            plugin_config = copy.deepcopy(config)
+            plugin_config['INPUT'] = os.path.dirname(config['INPUT'])
+
+            module = importlib.import_module(plugin)
+            module.register_mcss(
+                mcss_settings=plugin_config,
+                jinja_environment=self.env,
+                hooks_pre_page=self.hooks_pre_page,
+                hooks_post_run=self.hooks_post_run)
+
+        # Set up docutils
+        rst.directives.register_directive('presenter', PresenterDirective)
+        self.pub = docutils.core.Publisher(
+            writer=PresentationWriter(),
+            source_class=docutils.io.StringInput,
+            destination_class=docutils.io.StringOutput)
+        self.pub.set_components('standalone', 'restructuredtext', 'html')
+        self.pub.process_programmatic_settings(None, m.htmlsanity.docutils_settings, None)
+
+    # Returns list of files to watch for changes, input is always the first of
+    # them
+    def present(self):
+        basedir = os.path.dirname(self.config['INPUT'])
+
+        logging.debug("reading {}".format(self.config['INPUT']))
+        with open(self.config['INPUT'], 'r') as f: source = f.read()
+
+        # Call all registered page begin hooks
+        for hook in self.hooks_pre_page: hook()
+
+        self.pub.set_source(source=source, source_path=self.config['INPUT'])
+        self.pub.publish(enable_exit_status=True)
+
+        metadata = {}
+        for docinfo in self.pub.document.traverse(docutils.nodes.docinfo):
+            for element in docinfo.children:
+                # Custom named field
+                if element.tagname == 'field':
+                    name_elem, body_elem = element.children
+                    name = name_elem.astext()
+                    if name in self.config['FORMATTED_METADATA']:
+                        # If the metadata are formatted, format them. Use a special
+                        # translator that doesn't add <dd> tags around the content,
+                        # also explicitly disable the <p> around as we not need it
+                        # always.
+                        # TODO: uncrapify this a bit
+                        visitor = m.htmlsanity._SaneFieldBodyTranslator(self.pub.document)
+                        visitor.compact_field_list = True
+                        body_elem.walkabout(visitor)
+                        value = visitor.astext()
+                    else:
+                        value = body_elem.astext()
+                metadata[name.lower()] = value
+
+        # Add extra bundled files
+        extra_files = []
+        if 'css' in metadata:
+            extra_files += [i.strip() for i in metadata['css'].strip().split('\n')]
+        if 'js' in metadata:
+            extra_files += [i.strip() for i in metadata['js'].strip().split('\n')]
+        if 'bundle' in metadata:
+            extra_files += [i.strip() for i in metadata['bundle'].strip().split('\n')]
+            del metadata['bundle'] # not need to expose this to the template
+        if 'cover' in metadata:
+            extra_files += [metadata['cover']]
+
+        # Add images
+        for image in self.pub.document.traverse(docutils.nodes.image):
+            extra_files += [image['uri']]
+
+        # Set up the page structure for the template
+        page = Empty()
+        page.title = self.pub.writer.parts.get('title')
+        page.subtitle = self.pub.writer.parts.get('subtitle')
+        page.content = self.pub.writer.parts.get('body')
+        for key, value in metadata.items(): setattr(page, key, value)
+
+        # Write normal view
+        template = self.env.get_template('template.html')
+        rendered = template.render(page=page, PRESENTER_VIEW=False, **{k: v for k, v in self.config.items() if k != 'PRESENTER_VIEW'})
+
+        if not os.path.exists(config['OUTPUT']): os.makedirs(config['OUTPUT'])
+        output_file = os.path.join(config['OUTPUT'], 'index.html')
+        logging.debug("writing {}".format(output_file))
+        with open(output_file, 'w') as f: f.write(rendered)
+
+        # Write presenter view, if requested
+        if self.config['PRESENTER_VIEW']:
+            rendered = template.render(page=page, PRESENTER_VIEW=True, **{k: v for k, v in self.config.items() if k != 'PRESENTER_VIEW'})
+
+            output_file = os.path.join(config['OUTPUT'], self.config['PRESENTER_VIEW'])
+            logging.debug("writing {}".format(output_file))
+            with open(output_file, 'w') as f: f.write(rendered)
+
+        # Copy all referenced files
+        files_to_watch = []
+        for i in config['EXTRA_FILES'] + config['STYLESHEETS'] + ['presentation.js'] + extra_files:
+            # Skip absolute URLs
+            if urllib.parse.urlparse(i).netloc: continue
+
+            # If file is found relative to the input file, use that. Also add
+            # it to the watched list
+            if os.path.exists(os.path.join(basedir, i)):
+                i = os.path.join(basedir, i)
+                files_to_watch += [i]
+
+            # Otherwise use path relative to script directory
+            else:
+                i = os.path.join(os.path.dirname(os.path.realpath(__file__)), i)
+
+            logging.debug("copying {} to {}".format(i, config['OUTPUT']))
+            shutil.copy(i, os.path.join(config['OUTPUT'], os.path.basename(i)))
+
+        # Call all registered post-run hooks
+        # TODO: on exit only
+        for hook in self.hooks_post_run: hook()
+
+        return [config['INPUT']] + files_to_watch
+
+def file_watcher(paths):
+    # TODO: test this
+    logging.info("watching {} paths".format(len(paths)))
+    last_mtime = [0]*len(paths)
+    modified = None
+    while not modified:
+        for i, path in enumerate(paths):
+            mtime = os.stat(path).st_mtime
+            # Avoid reporting the file has modified right after start
+            if not last_mtime[i]:
+                last_mtime[i] = mtime
+            elif mtime > last_mtime[i]:
+                last_mtime[i] = mtime
+                modified = path
+        yield modified
+
+# Paths[0] has to be the input file
+def autoreload(presenter, paths):
+    while True:
+        for modified in file_watcher(paths):
+            if modified:
+                logging.info("modified {}, updating".format(os.path.basename(modified)))
+                paths = presenter.present()
+            else:
+                time.sleep(1)
+
+def listen(output, port):
+    os.chdir(output)
+    # TODO: too specific, move this away
+    http.server.SimpleHTTPRequestHandler.extensions_map['.wasm'] = 'application/wasm'
+    httpd = http.server.HTTPServer(('', port), http.server.SimpleHTTPRequestHandler)
+    httpd.serve_forever()
+
+if __name__ == '__main__': # pragma: no cover
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input', help="input reST file with the presentation")
+    parser.add_argument('--presenter', nargs='?', const='presenter.html', default=None, help="generate a presenter view")
+    parser.add_argument('--templates', help="template directory", default=default_templates)
+    parser.add_argument('--debug', help="verbose debug output", action='store_true')
+    parser.add_argument('-r', '--autoreload', help="reload on input file change", action='store_true')
+    parser.add_argument('-l', '--listen', help="serve the output via a webserver", action='store_true')
+    parser.add_argument('-p', '--port', help="", default='8000', type=int)
+    args = parser.parse_args()
+
+    # Load configuration from a file, if the input is a Python script,
+    # otherwise take the file as the input and use default config
+    config = copy.deepcopy(default_config)
+    if args.input.endswith('.py'):
+        name, _ = os.path.splitext(os.path.basename(args.input))
+        module = SourceFileLoader(name, args.input).load_module()
+        if module is not None:
+            config.update((k, v) for k, v in inspect.getmembers(module) if k.isupper())
+        config['INPUT'] = os.path.join(os.path.dirname(args.input), config['INPUT'])
+    else:
+        config['INPUT'] = args.input
+
+    # Make the output path relative to input, enable presenter view if
+    # specified on the command-line
+    config['OUTPUT'] = os.path.join(os.path.dirname(config['INPUT']), config['OUTPUT'])
+    if args.presenter: config['PRESENTER_VIEW'] = args.presenter
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    # Set up the presneter
+    presenter = Presenter(args.templates, config)
+    paths = presenter.present()
+
+    # Autoreload / listen
+    if args.autoreload and args.listen:
+        logging.info("serving on http://localhost:{} with autoreload ...".format(args.port))
+        queue = multiprocessing.Queue()
+        reloader = multiprocessing.Process(target=autoreload, args=(presenter, paths))
+        server = multiprocessing.Process(target=listen, args=(config['OUTPUT'], args.port))
+        reloader.start()
+        server.start()
+        e = queue.get()
+        reloader.terminate()
+        server.terminate()
+        logging.critical(e)
+    elif args.autoreload:
+        logging.info("started autoreload...")
+        autoreload(presenter, paths)
+    elif args.listen:
+        logging.info("serving on http://localhost:{} ...".format(args.port))
+        listen(config['OUTPUT'], args.port)

--- a/presentation/presentation.js
+++ b/presentation/presentation.js
@@ -1,0 +1,121 @@
+/*
+    This file is part of m.css.
+
+    Copyright © 2017, 2018 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+"use strict"; /* it summons the Cthulhu in a proper way, they say */
+
+let mainView = null;
+
+function flip(id) {
+    window.location.hash = '#' + id;
+
+    /* This is the main view, send the change to the presenter window as well */
+    if(window.opener)
+        window.opener.location.hash = '#' + id;
+
+    /* This is the presenter view */
+    else {
+        /* Send the change to the main view as well */
+        if(mainView && !mainView.closed) {
+            mainView.location.hash = '#' + id;
+
+        /* Otherwise update the connection status */
+        } else {
+            mainView = null;
+            let status = document.getElementById('main-view-connection-status');
+            if(status) {
+                status.innerHTML = 'disconnected';
+                status.className = 'm-text m-danger';
+            }
+        }
+    }
+}
+
+/* Flipping: when editing, the titles can change and then locating the current
+   slide won't work anymore. Prev then jumps to the cover page, next to a page
+   right after cover. */
+
+function flipPrev() {
+    let current = document.getElementById(window.location.hash.substr(1));
+    if(current) {
+        let prev = current.previousElementSibling;
+        if(prev && prev.id && prev.tagName == 'SECTION') flip(prev.id);
+    } else flip("cover");
+}
+
+function flipNext() {
+    let current = document.getElementById(window.location.hash.substr(1));
+    if(!current) current = document.getElementById("cover");
+    let next = current.nextElementSibling;
+    if(next && next.id && next.tagName == 'SECTION') flip(next.id);
+}
+
+document.addEventListener('keydown', function(event) {
+    /* TODO home key for the first slide (what is the first?) */
+
+    /* Just opened, flip to cover */
+    if(!window.location.hash && (event.key == 'ArrowLeft' || event.key == 'ArrowRight'))
+        flip('cover');
+
+    /* Flip to previous */
+    else if(event.key == 'ArrowLeft') flipPrev();
+
+    /* Flip to next */
+    else if(event.key == 'ArrowRight') flipNext();
+});
+
+let touchStart = null;
+
+document.addEventListener('touchstart', function(event) {
+    touchStart = event.touches.length == 1 ? event.touches.item(0).clientX : null;
+});
+
+document.addEventListener('touchend', function(event) {
+    var offset = 100;
+
+    if(touchStart) {
+        let end = event.changedTouches.item(0).clientX;
+
+        /* Just opened, flip to cover */
+        if(!window.location.hash && (end > touchStart + offset || end < touchStart - offset))
+            flip('cover');
+
+        /* Flip to previous */
+        else if(end > touchStart + offset) flipPrev();
+
+        /* FLip to next */
+        else if(end < touchStart - offset) flipNext();
+    }
+
+    touchStart = null;
+});
+
+function openMainView(link) {
+    mainView = window.open(link.getAttribute('href'), "main-view");
+    let status = document.getElementById('main-view-connection-status');
+    if(status) {
+        status.innerHTML = 'connected';
+        status.className = 'm-text m-success';
+    }
+    return false;
+}

--- a/presentation/template.html
+++ b/presentation/template.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="{% if page.lang %}{{ page.lang }}{% else %}{{ DEFAULT_LANG }}{%endif %}"{% if PRESENTER_VIEW %} class="m-presenter"{% endif %}{% if not M_DISABLE_SOCIAL_META_TAGS %} prefix="og: http://ogp.me/ns#"{% endif %}>
+<head>
+  <meta charset="UTF-8" />
+  <title>{{ page.title }}</title>
+  {% for href in STYLESHEETS %}
+  <link rel="stylesheet" href="{{ href|basename_or_url|e }}" />
+  {% endfor %}
+  {% if page.css %}
+  {% set styles = page.css.strip().split('\n') %}
+  {% for style in styles %}
+  <link rel="stylesheet" href="{{ style|trim|basename_or_url|e }}" />
+  {% endfor %}
+  {% endif %}
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  {% if M_THEME_COLOR %}
+  <meta name="theme-color" content="{{ M_THEME_COLOR }}" />
+  {% endif %}
+  {% if not M_DISABLE_SOCIAL_META_TAGS %}
+  {% if M_SOCIAL_TWITTER_SITE %}
+  <meta name="twitter:site" content="{{ M_SOCIAL_TWITTER_SITE }}" />
+  {% endif %}
+  {% if M_SOCIAL_TWITTER_SITE_ID %}
+  <meta name="twitter:site:id" content="{{ M_SOCIAL_TWITTER_SITE_ID }}" />
+  {% endif %}
+  {% endif %}
+</head>
+<body>
+<div class="m-container m-container-inflatable">
+<div class="m-row">
+<div class="{% if PRESENTER_VIEW %}m-col-m-10 m-push-m-1{% else %}m-col-m-12 m-nopad{% endif %}">
+<article>
+  {% if PRESENTER_VIEW %}
+  <aside>
+    <h1>{{ page.title }}</h1>
+    <h2>{{ page.subtitle }}</h2>
+    <div class="m-row">
+      <div class="m-col-t-4 m-push-t-2">
+        <div class="m-button m-primary m-fullwidth"><a href="#cover">Start presentation</a></div>
+      </div>
+      <div class="m-col-t-4 m-push-t-2">
+        <div class="m-button m-success m-fullwidth"><a href="index.html#cover" onclick="return openMainView(this);">Open main view</a></div>
+      </div>
+    </div>
+    <aside class="m-presenter">Main view: <span id="main-view-connection-status" class="m-text m-danger">not connected</span></aside>
+  </aside>
+  {% endif %}
+  <section id="cover"{% if page.cover %} class="m-presentation-cover" style="background-image: url('{{ page.cover|basename_or_url|e }}');"{% endif %}>
+    <h1>{{ page.title }}</h1>
+    <h2>{{ page.subtitle }}</h2>
+  </section>
+<!-- content -->
+{{ page.content|trim }}
+{% if page.after %}
+{{ page.after|trim }}
+{% endif %}
+<!-- /content -->
+</article>
+</div>
+</div>
+</div>
+<script src="{{ 'presentation.js'|basename_or_url|e }}"></script>
+{% if page.js %}
+{% set scripts = page.js.strip().split('\n') %}
+{% for script in scripts %}
+<script src="{{ script|trim|basename_or_url|e }}"></script>
+{% endfor %}
+{% endif %}
+</body>
+</html>

--- a/presentation/test-presenter.html
+++ b/presentation/test-presenter.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en" class="m-presenter">
+<head>
+  <meta charset="UTF-8" />
+  <title>A presentation</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="../css/m-dark-presentation.css" />
+</head>
+<body>
+<div class="m-container m-container-inflatable">
+<div class="m-row">
+<div class="m-col-l-10 m-push-l-1">
+<article>
+  <section id="cover">
+    <h1>A presentation</h1>
+    <h2>A presentation subtitle</h2>
+    <aside class="m-presenter">
+      Presenter notes.
+    </aside>
+  </section>
+  <section id="slide0">
+    <h2>Slide zero</h2>
+    <ul>
+      <li>Content</li>
+    </ul>
+    <aside class="m-presenter">
+      Presenter notes.
+    </aside>
+  </section>
+  <section id="slide1">
+    <h2>Slide one</h2>
+    <ul>
+      <li>Content</li>
+    </ul>
+    <aside class="m-presenter">
+      More presenter notes.
+    </aside>
+  </section>
+</article>
+</div>
+</div>
+</div>
+<script src="presentation.js"></script>
+</main>
+</body>
+</html>

--- a/presentation/test.html
+++ b/presentation/test.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>A presentation</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="../css/m-dark-presentation.css" />
+  <script src="presentation.js"></script>
+</head>
+<body>
+<div class="m-container m-container-inflatable">
+<div class="m-row">
+<div class="m-col-l-12">
+<article>
+  <aside>
+    <h1>A presentation</h1>
+    <p>This is a presentation powered by m.css. You have the following
+    options:</p>
+    <div class="m-row">
+      <div class="m-col-m-4 m-push-m-2">
+        <div class="m-button m-primary"><a href="#cover">Start presentation</a></div>
+      </div>
+      <div class="m-col-m-4 m-push-m-2">
+        <div class="m-button m-success"><a href="test-presenter.html#cover" onclick="return openPresenterView(this);">Presenter view</a></div>
+      </div>
+    </div>
+  </aside>
+  <section id="cover">
+    <h1>A presentation</h1>
+    <h2>A presentation subtitle</h2>
+    <aside class="m-presenter">
+      Presenter notes.
+    </aside>
+  </section>
+  <section id="slide0">
+    <h2>Slide zero</h2>
+    <ul>
+      <li>Content</li>
+    </ul>
+    <aside class="m-presenter">
+      Presenter notes.
+    </aside>
+  </section>
+  <section id="slide1">
+    <h2>Slide one</h2>
+    <ul>
+      <li>Content</li>
+    </ul>
+    <aside class="m-presenter">
+      More presenter notes.
+    </aside>
+  </section>
+</article>
+</div>
+</div>
+</div>
+</body>
+</html>

--- a/site/pelicanconf.py
+++ b/site/pelicanconf.py
@@ -79,6 +79,7 @@ M_LINKS_NAVBAR1 = [('Why?', 'why/', 'why', []),
                         ('Typography', 'css/typography/', 'css/typography'),
                         ('Components', 'css/components/', 'css/components'),
                         ('Page layout', 'css/page-layout/', 'css/page-layout'),
+                        ('Presentation', 'css/presentation/', 'css/presentation'),
                         ('Themes', 'css/themes/', 'css/themes')]),
                    ('Themes', 'themes/', 'themes', [
                         ('Writing reST content', 'themes/writing-rst-content/', 'pelican/writing-content'),
@@ -96,6 +97,7 @@ M_LINKS_NAVBAR2 = [('Plugins', 'plugins/', 'plugins', [
                         ('Plots and graphs', 'plugins/plots-and-graphs/', 'plugins/plots-and-graphs'),
                         ('Metadata', 'plugins/metadata/', 'plugins/metadata'),
                         ('Sphinx', 'plugins/sphinx/', 'plugins/sphinx')]),
+                   ('Presentation tool', 'presentation/', 'presentation', []),
                    ('GitHub', 'https://github.com/mosra/m.css', '', [])]
 
 M_LINKS_FOOTER1 = [('m.css', '/'),
@@ -111,6 +113,7 @@ M_LINKS_FOOTER2 = [('CSS', 'css/'),
                    ('Typography', 'css/typography/'),
                    ('Components', 'css/components/'),
                    ('Page layout', 'css/page-layout/'),
+                   ('Presentation', 'css/presentation/'),
                    ('Themes', 'css/themes/')]
 
 M_LINKS_FOOTER3 = [('Themes', 'themes/'),
@@ -119,7 +122,9 @@ M_LINKS_FOOTER3 = [('Themes', 'themes/'),
                    ('', ''),
                    ('Doc generators', 'documentation/'),
                    ('Doxygen C++ theme', 'documentation/doxygen/'),
-                   ('Python documentation', 'documentation/python/')]
+                   ('Python documentation', 'documentation/python/'),
+                   ('', ''),
+                   ('Presentation tool', 'presentation/')]
 
 M_LINKS_FOOTER4 = [('Plugins', 'plugins/'),
                    ('HTML sanity', 'plugins/htmlsanity/'),
@@ -222,4 +227,4 @@ CATEGORIES_SAVE_AS = None # Not used
 TAGS_SAVE_AS = None # Not used
 
 SLUGIFY_SOURCE = 'basename'
-PATH_METADATA = '(?P<slug>.+).rst'
+PATH_METADATA = '(?P<slug>.+).(rst|html)'


### PR DESCRIPTION
The branch has been around since 2018, just not tested, documented or actually published. Time to change that!

Features:

- Write your slides with the usual reST syntax
  - Meaning you can easily reuse content from presentations to blog posts and vice versa
- Present in a web browser
  - With all the advantages it has, like embedded videos or WebGL content
- Print-only CSS to save as a PDF using a PDF printer in the browser
- Tiny amount of JS to navigate back and forth
- Synchronized presenter view with notes in another window

Things left to do:

- [ ] Write tests
- [ ] Refresh the docs to what makes sense in 2022, especially regarding PDF print
- [ ] Update copyright years, heh
- [ ] Cleanup the `m.htmlsanity` additions
- [ ] Figure out a way to enforce use of the `.m-*-t` CSS classes for advanced layouts, as the `.m-*-s`, `m` and `l` are window-size-dependent and break especially during print (or maybe change it so it behaves the same for all sizes? turn the screen sizes into a variable and change it here to something else?)
- [ ] Sync plugin usage / handling with the Python doc generator