### PR TITLE
Fix various typos

### DIFF
--- a/doc/admire/math.rst
+++ b/doc/admire/math.rst
@@ -97,7 +97,7 @@ m.css math
             .. button-warning:: {filename}/css/components.rst#math
                 :class: m-fullwidth
 
-                See the possibilites
+                See the possibilities
 
     .. container:: m-col-m-4
 

--- a/doc/css/components.rst
+++ b/doc/css/components.rst
@@ -1246,7 +1246,7 @@ with :css:`.m-line`, error bars with :css:`.m-error`. Use
 
 .. note-info::
 
-    Plot styling is designed to be used with extenal tools, for example Python
+    Plot styling is designed to be used with external tools, for example Python
     Matplotlib. If you use Pelican, m.css has a
     `m.plots <{filename}/plugins/plots-and-graphs.rst#plots>`__ plugin that
     allows you to produce plots using :rst:`.. plot::` directives directly in

--- a/doc/css/page-layout.rst
+++ b/doc/css/page-layout.rst
@@ -420,7 +420,7 @@ the fold", *not* the cover image.
         </div>
       </div>
       <div class="m-container">
-        <!-- content "below the fold" folows -->
+        <!-- content "below the fold" follows -->
       </div>
     </article></main>
 

--- a/doc/css/themes.rst
+++ b/doc/css/themes.rst
@@ -123,7 +123,7 @@ together and it will create a ``*.compiled.css`` file in the same directory:
     cd css
     ./postprocess.py m-dark.css # Creates a m-dark.compiled.css file
 
-`Modifying the Pygments higlighting style`_
+`Modifying the Pygments highlighting style`_
 -------------------------------------------
 
 If you want to modify the Pygments style, it's a bit more involved. You need to

--- a/doc/documentation/doxygen.rst
+++ b/doc/documentation/doxygen.rst
@@ -73,7 +73,7 @@ switch.
 
 .. note-info::
 
-    The script requires at least Doxygen 1.8.14, but preferrably version 1.8.15
+    The script requires at least Doxygen 1.8.14, but preferably version 1.8.15
     and newer. Some features depend on newer versions, in that case the
     documentation mentions which version contains the support.
 
@@ -205,7 +205,7 @@ In addition to features `shared by all doc generators <{filename}/documentation.
 
     This list presents my opinions. Not everybody likes my opinions.
 
-Features that I don't see a point in because they just artifically inflate the
+Features that I don't see a point in because they just artificially inflate the
 amount of generated content for no added value.
 
 -   Class hierarchy graphs are ignored (it only inflates the documentation with
@@ -600,7 +600,7 @@ If the title is :py:`None`, it's taken implicitly from the page it links to.
 Empty :py:`LINKS_NAVBAR2` will cause the navigation appear in a single column,
 setting both empty will cause the navbar links to not be rendered at all.
 
-A menu item is higlighted if a compound with the same ID is the current page
+A menu item is highlighted if a compound with the same ID is the current page
 (and similarly for the special ``pages``, ... IDs).
 
 Alternatively, a link can be a plain HTML instead of the first pair of tuple
@@ -1269,7 +1269,7 @@ rendered HTML output:
 
 It's possible to combine ``@par`` with ``@parblock`` to create blocks, notes
 and other `m.css components <{filename}/css/components.rst>`_ with arbitrary
-contents. The ``@par`` command visuals can be fully overriden by putting ``@m_class`` in front, the ``@parblock`` after will ensure everything will
+contents. The ``@par`` command visuals can be fully overridden by putting ``@m_class`` in front, the ``@parblock`` after will ensure everything will
 belong inside. A bit recursive example:
 
 .. code-figure::
@@ -1374,7 +1374,7 @@ the page will be discoverable both using its primary title and using
 *TCB spline support*, in the second and third case the two overloads of the
 :cpp:`lerp()` function are discoverable also via :cpp:`mix()`, displaying
 either *GLSL mix()* or *GLSL mix(genType, genType, float)* in the search
-results. The last parameter is suffix length, needed to correctly higlight the
+results. The last parameter is suffix length, needed to correctly highlight the
 *mix* substring when there are additional characters at the end of the title.
 If not specified, it defaults to :cpp:`0`, meaning the search string is a
 suffix of the title.
@@ -1653,9 +1653,9 @@ Filename                Use
                         saved as ``*-example.html``
 ``file.html``           File documentation, read from ``*.xml`` and saved as
                         ``*.html``
-``namespace.html``      Namespace documentation, read fron ``namespace*.xml``
+``namespace.html``      Namespace documentation, read from ``namespace*.xml``
                         and saved as ``namespace*.html``
-``group.html``          Module documentation, read fron ``group_*.xml``
+``group.html``          Module documentation, read from ``group_*.xml``
                         and saved as ``group_*.html``
 ``page.html``           Page, read from ``*.xml``/``indexpage.xml`` and saved
                         as ``*.html``/``index.html``

--- a/doc/documentation/python.rst
+++ b/doc/documentation/python.rst
@@ -203,7 +203,7 @@ Variable                            Description
                                     put into the footer. If not set, a default
                                     generic text is used. If empty, no footer
                                     is rendered at all.
-:py:`FORMATTED_METADATA: List[str]` Which meatadata fields should be formatted
+:py:`FORMATTED_METADATA: List[str]` Which metadata fields should be formatted
                                     in documentation pages. By default only
                                     the ``summary`` field is.
 :py:`PLUGINS: List[str]`            List of `plugins <{filename}/plugins.rst>`_
@@ -504,7 +504,7 @@ In case the autodetection includes more than you want or, conversely, you need
 to include names that would otherwise be excluded (such as underscored names),
 you can temporarily override the :py:`__all__` attribute when generating the
 docs. For example, the following will list just the :py:`pow()` and :py:`log()`
-funtions from the :py:`math` module, ignoring the rest:
+functions from the :py:`math` module, ignoring the rest:
 
 .. code:: py
 
@@ -516,7 +516,7 @@ funtions from the :py:`math` module, ignoring the rest:
 In other cases, especially when native modules are involved, the inspected name locations might not be what you want. By putting the names into :py:`__all__`
 you tell the script it should map the inspected location to the one provided.
 Note you should also hide the original location from the script to avoid
-duplicate definitons (unless it's underscored, in which case it'll get ignored
+duplicate definitions (unless it's underscored, in which case it'll get ignored
 automatically).
 
 .. code:: py
@@ -763,7 +763,7 @@ to :py:`OUTPUT` with the leading dirs stripped from the path.
 ==========
 
 The :abbr:`reST <reStructuredText>` content is not limited to just the builtin
-functionality and it's possible to extend it via plugins eiter
+functionality and it's possible to extend it via plugins either
 `from m.css itself <{filename}/plugins.rst>`_ or 3rd party ones. See
 documentation of each plugin to see its usage; the
 `m.htmlsanity <{filename}/plugins/htmlsanity.rst>`_ plugin is used
@@ -981,7 +981,7 @@ Keyword argument    Content
                     :py:`css_classes`   List of CSS classes to add to the
                                         :html:`<a>` tag. Internal entries
                                         usually have :py:`['m-doc']` while
-                                        exteral have :py:`['m-doc-external']`.
+                                        external have :py:`['m-doc-external']`.
                     =================== =======================================
 =================== ===========================================================
 

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -32,7 +32,7 @@ Plugins
 In addition to providing a theme for `Pelican <{filename}/themes/pelican.rst>`_
 or `Doxygen <{filename}/documentation/doxygen.rst>`_  that styles the overall
 page layout and basic typography, m.css also contains a collection of plugins,
-extending the capabilities futher.
+extending the capabilities further.
 
 `Usage`_
 ========

--- a/doc/plugins/htmlsanity.rst
+++ b/doc/plugins/htmlsanity.rst
@@ -131,7 +131,7 @@ Additionally, the following m.css-specific changes are done:
 -   Footnotes and footnote references have the :css:`.m-footnote`
     `styling classes <{filename}/css/typography.rst#footnotes-and-footnote-references>`_
     applied
--   Links that are just URLs have :css:`.m-link-wrap` appied `to better wrap on narrow screens <{filename}/css/typography.rst#footnotes-and-footnote-references>`_.
+-   Links that are just URLs have :css:`.m-link-wrap` applied `to better wrap on narrow screens <{filename}/css/typography.rst#footnotes-and-footnote-references>`_.
     Note that it's also possible to apply this and other CSS classes explicitly
     with the `m.link <{filename}/plugins/links.rst#stylable-links>`_ plugin.
 
@@ -186,7 +186,7 @@ included in the :py:`FORMATTED_FIELDS`. See for yourself:
     *"Autres temps, autres mœurs"*
 
 The default language is taken from the standard :py:`DEFAULT_LANG` option,
-which defaults to :py:`'en'`, and can be also overriden on per-page or
+which defaults to :py:`'en'`, and can be also overridden on per-page or
 per-article basis using the :rst:`:lang:` metadata option. This feature is
 controlled by the :py:`M_HTMLSANITY_SMART_QUOTES` option, which, similarly to
 the builtin :py:`TYPOGRIFY` option, defaults to :py:`False`.
@@ -387,7 +387,7 @@ pass language name to the ``lang`` argument. You can also take the value from
 
 Sometimes, on the other hand, you might want to de-hyphenate text that was
 already hyphenated, for example to avoid potential issues in :html:`<meta>`
-tags. The ``dehyphenate`` filter simply removes all occurences of :html:`&shy;`
+tags. The ``dehyphenate`` filter simply removes all occurrences of :html:`&shy;`
 from passed text. The ``enable`` argument works the same as with the
 ``hyphenate`` filter.
 

--- a/doc/themes/pelican.rst
+++ b/doc/themes/pelican.rst
@@ -339,21 +339,21 @@ and `Twitter Card <https://developer.twitter.com/en/docs/tweets/optimize-with-ca
     / :py:`M_SOCIAL_TWITTER_SITE_ID``, if available
 -   Global ``og:title`` / ``twitter:title`` is set to :py:`M_BLOG_NAME` on
     index and archive pages and to category/author/tag name on particular
-    filtering pages. This is overriden by particular pages and articles.
+    filtering pages. This is overridden by particular pages and articles.
 -   Global ``og:url`` is set to :py:`M_BLOG_URL` on index and archive pages and
     to category/author/tag URL on particular filtering pages. Pagination is
-    *not* included in the URL. This is overriden by particular pages and
+    *not* included in the URL. This is overridden by particular pages and
     articles.
 -   Global ``og:image`` / ``twitter:image`` is set to the
     :py:`M_SOCIAL_IMAGE` setting, if available. The image is expected to be
     smaller and square; Pelican internal linking capabilities are *not*
-    supported in this setting. This can be overriden by particular pages and
+    supported in this setting. This can be overridden by particular pages and
     articles.
 -   Global ``twitter:card`` is set to ``summary``. This is further affected by
     metadata of particular pages and articles.
 -   Global ``og:description`` / ``twitter:description`` is set to
     :py:`M_SOCIAL_BLOG_SUMMARY` on index and archive pages.
--   Global ``og:type`` is set to ``website``. This is overriden by particular
+-   Global ``og:type`` is set to ``website``. This is overridden by particular
     pages and articles.
 
 See `(Social) meta tags for pages`_ and `(Social) meta tags for articles`_
@@ -383,7 +383,7 @@ Example configuration to give sane defaults to all social meta tags:
 
     The theme assumes that the global site image is smaller and square in order
     to appear just as a small thumbnail next to a link, not as large cover
-    image above it --- the reasoning beind is that there's no point in annoying
+    image above it --- the reasoning behind is that there's no point in annoying
     the users by decorating the global site links with the exact same large
     image.
 
@@ -501,7 +501,7 @@ present) is :py:`False`.
         FORMATTED_FIELDS += ['landing']
 
 Example of a fully custom index page that overrides the default theme index
-page (which would just list all the articles) is below. Note the overriden save
+page (which would just list all the articles) is below. Note the overridden save
 destination and URL.
 
 .. code:: rst

--- a/documentation/_search.py
+++ b/documentation/_search.py
@@ -38,7 +38,7 @@ search_filename = f'search-v{searchdata_format_version}.js'
 searchdata_filename = f'{{search_filename_prefix}}-v{searchdata_format_version}.bin'
 searchdata_filename_b85 = f'{{search_filename_prefix}}-v{searchdata_format_version}.js'
 
-# In order to be both space-efficient and flexible enough to accomodate for
+# In order to be both space-efficient and flexible enough to accommodate for
 # larger projects, the bit counts for particular data types can vary in each
 # file. There's the following categories:
 #

--- a/documentation/doxygen.py
+++ b/documentation/doxygen.py
@@ -1753,7 +1753,7 @@ def parse_desc_internal(state: State, element: ET.Element, immediate_parent: ET.
                 assert out.parsed.startswith('<p>') and out.parsed.endswith('</p>')
                 out.parsed = out.parsed[3:-4]
 
-    # Strip superfluous <p> for simple elments (list items, parameter and
+    # Strip superfluous <p> for simple elements (list items, parameter and
     # return value description, table cells), but only if there is just a
     # single paragraph
     elif (element.tag in ['listitem', 'parameterdescription', 'entry'] or (element.tag == 'simplesect' and element.attrib['kind'] == 'return')) and not has_block_elements and paragraph_count == 1 and out.parsed:
@@ -2535,7 +2535,7 @@ def parse_xml(state: State, xml: str):
     state.current = os.path.basename(xml)
 
     # All these early returns were logged in extract_metadata() already, no
-    # need to print the same warnings/erorrs twice. Keep the two consistent.
+    # need to print the same warnings/errors twice. Keep the two consistent.
     if state.current == 'Doxyfile.html':
         return
 
@@ -3451,7 +3451,7 @@ def parse_index_xml(state: State, xml):
     return parsed
 
 def parse_doxyfile(state: State, doxyfile, values = None):
-    # Use top-level Doxyfile path as base, don't let it get overriden by
+    # Use top-level Doxyfile path as base, don't let it get overridden by
     # subsequently @INCLUDE'd Doxyfile
     if not state.basedir:
         state.basedir = os.path.dirname(doxyfile)

--- a/documentation/python.py
+++ b/documentation/python.py
@@ -409,7 +409,7 @@ def crawl_class(state: State, path: List[str], class_):
             if hasattr(previous_entry, 'object') and id(previous_entry.object) == id(class_):
                 break
         else: assert False, "%s marked as crawled but can't find it" % '.'.join(path)
-        logging.error("Class %s previously found in %s, only one occurence will be chosen. Ensure each class is exposed only in a single module for generating correct documentation.", '.'.join(path), '.'.join(previous_entry.path))
+        logging.error("Class %s previously found in %s, only one occurrence will be chosen. Ensure each class is exposed only in a single module for generating correct documentation.", '.'.join(path), '.'.join(previous_entry.path))
         state.name_map['.'.join(path)] = previous_entry
         return
 
@@ -445,7 +445,7 @@ def crawl_class(state: State, path: List[str], class_):
 
             crawl_class(state, subpath, object)
 
-        # Crawl enum values (they also add itself ot the name_map)
+        # Crawl enum values (they also add itself to the name_map)
         elif type_ == EntryType.ENUM:
             if is_underscored_and_undocumented(state, type_, subpath, object.__doc__): continue
 

--- a/documentation/test/test_search.py
+++ b/documentation/test/test_search.py
@@ -219,7 +219,7 @@ __init__ [{}]
     def test_23bit_file_offset_too_small(self):
         trie = Trie()
 
-        # The hight bit of the child offset stores a lookahead barrier, so the
+        # The high bit of the child offset stores a lookahead barrier, so the
         # file has to be smaller than 8M, not 16. Python has a recursion limit
         # of 1000, so we can't really insert a 8M character long string.
         # Instead, insert one 130-character string where each char has 32k

--- a/documentation/test_doxygen/contents_blocks/input.dox
+++ b/documentation/test_doxygen/contents_blocks/input.dox
@@ -132,7 +132,7 @@ This gets hidden because internal docs are not enabled by default.
 
 /** @page other Other page
 
-@todo Diffferent TODO
+@todo Different TODO
 
 */
 

--- a/documentation/test_doxygen/contents_blocks/todo.html
+++ b/documentation/test_doxygen/contents_blocks/todo.html
@@ -22,7 +22,7 @@
         <h1>
           Todo List
         </h1>
-<dl class="m-doc"><dt>page <a href="index.html" class="m-doc">Main Page</a></dt><dd><a name="_todo000001"></a>Or a TODO.</dd><dt>Page <a href="other.html" class="m-doc">Other page</a></dt><dd><a name="_todo000002"></a>Diffferent TODO</dd></dl>
+<dl class="m-doc"><dt>page <a href="index.html" class="m-doc">Main Page</a></dt><dd><a name="_todo000001"></a>Or a TODO.</dd><dt>Page <a href="other.html" class="m-doc">Other page</a></dt><dd><a name="_todo000002"></a>Different TODO</dd></dl>
       </div>
     </div>
   </div>

--- a/documentation/test_doxygen/contents_blocks/todo_1814.html
+++ b/documentation/test_doxygen/contents_blocks/todo_1814.html
@@ -22,7 +22,7 @@
         <h1>
           Todo List
         </h1>
-<dl class="m-doc"><dt><a name="_todo000001"></a>page <a href="index.html" class="m-doc">Main Page</a></dt><dd>Or a TODO.</dd><dt><a name="_todo000002"></a>Page <a href="other.html" class="m-doc">Other page</a></dt><dd>Diffferent TODO</dd></dl>
+<dl class="m-doc"><dt><a name="_todo000001"></a>page <a href="index.html" class="m-doc">Main Page</a></dt><dd>Or a TODO.</dd><dt><a name="_todo000002"></a>Page <a href="other.html" class="m-doc">Other page</a></dt><dd>Different TODO</dd></dl>
       </div>
     </div>
   </div>

--- a/documentation/test_doxygen/contents_unexpected_sections/File.h
+++ b/documentation/test_doxygen/contents_unexpected_sections/File.h
@@ -1,11 +1,11 @@
 /** @file
 @brief A file
 
-@return Files don't return anyhting.
+@return Files don't return anything.
 
 @section section A section
 
-@tparam huh Setions shouldn't have template params.
+@tparam huh Sections shouldn't have template params.
 */
 
 /**

--- a/documentation/test_doxygen/cpp_friends/File.h
+++ b/documentation/test_doxygen/cpp_friends/File.h
@@ -5,7 +5,7 @@
 /**
 @brief A friend class
 
-Not displayed among @ref Class friends becase Doxygen doesn't provide any
+Not displayed among @ref Class friends because Doxygen doesn't provide any
 useful info for it.
 */
 class FriendClassWarning {};
@@ -13,7 +13,7 @@ class FriendClassWarning {};
 /**
 @brief A friend class
 
-Not displayed among @ref Class friends becase Doxygen doesn't provide any
+Not displayed among @ref Class friends because Doxygen doesn't provide any
 useful info for it.
 */
 class GroupedFriendClassWarning {};

--- a/documentation/test_doxygen/cpp_function_attributes/classDerived.html
+++ b/documentation/test_doxygen/cpp_function_attributes/classDerived.html
@@ -51,7 +51,7 @@
             <dt id="a0b1e72ba2c219253091525588d75fdd4">
               <span class="m-doc-wrap-bumper">void <a href="#a0b1e72ba2c219253091525588d75fdd4" class="m-doc-self">doThing</a>(</span><span class="m-doc-wrap">) const <span class="m-label m-flat m-warning">override</span> <span class="m-label m-flat m-success">noexcept(…)</span></span>
             </dt>
-            <dd>Do a thing, overriden, now protected.</dd>
+            <dd>Do a thing, overridden, now protected.</dd>
           </dl>
         </section>
         <section id="pri-methods">

--- a/documentation/test_doxygen/cpp_function_attributes/input.h
+++ b/documentation/test_doxygen/cpp_function_attributes/input.h
@@ -86,7 +86,7 @@ class Base {
 /** @brief A derived class */
 class Derived: public Base {
     protected:
-        /** @brief Do a thing, overriden, now protected */
+        /** @brief Do a thing, overridden, now protected */
         void doThing() const noexcept(false) override;
 
     private:

--- a/documentation/test_doxygen/layout_search_binary/Doxyfile
+++ b/documentation/test_doxygen/layout_search_binary/Doxyfile
@@ -6,4 +6,4 @@ XML_OUTPUT              =
 ##! M_LINKS_NAVBAR1     =
 ##! M_LINKS_NAVBAR2     =
 ##! M_SEARCH_DOWNLOAD_BINARY = YES
-##! M_SEARCH_HELP       = "Halp."
+##! M_SEARCH_HELP       = "Help."

--- a/documentation/test_doxygen/layout_search_binary/index.html
+++ b/documentation/test_doxygen/layout_search_binary/index.html
@@ -59,7 +59,7 @@
           </form>
           <noscript class="m-text m-danger m-text-center">Unlike everything else in the docs, the search functionality <em>requires</em> JavaScript.</noscript>
           <div id="search-help" class="m-text m-dim m-text-center">
-            Halp.
+            Help.
           </div>
           <div id="search-notfound" class="m-text m-warning m-text-center">Sorry, nothing was found.</div>
           <ul id="search-results"></ul>

--- a/documentation/test_python/__init__.py
+++ b/documentation/test_python/__init__.py
@@ -40,7 +40,7 @@ _camelcase_to_snakecase = re.compile('((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))')
 # filesystem location. For a `test_inspect.NameMapping` class, it will look
 # for the `inspect_name_mapping` directory. If the class name is equivalent to
 # the filename (e.g. `test_page.Page`), then it will be looking for just `page`
-# instead of `page_page`. If needed, the directory name can be overriden by
+# instead of `page_page`. If needed, the directory name can be overridden by
 # passing it via dir to __init__().
 class BaseTestCase(unittest.TestCase):
     def __init__(self, *args, dir=None, **kwargs):

--- a/documentation/test_python/content/content/__init__.py
+++ b/documentation/test_python/content/content/__init__.py
@@ -18,7 +18,7 @@ class Class:
         """A dunder method"""
 
     def method(self):
-        """This summary will get overriden from the docs"""
+        """This summary will get overridden from the docs"""
 
     def method_with_details(self):
         pass

--- a/documentation/test_python/page/another.html
+++ b/documentation/test_python/page/another.html
@@ -22,7 +22,7 @@
         <h1>
           Another page
         </h1>
-        <p>Here's some summary. <strong>It's formated as well.</strong></p>
+        <p>Here's some summary. <strong>It's formatted as well.</strong></p>
 <p>And the <em>text</em>.</p>
       </div>
     </div>

--- a/documentation/test_python/page/another.rst
+++ b/documentation/test_python/page/another.rst
@@ -1,6 +1,6 @@
 Another page
 ############
 
-:summary: Here's some summary. **It's formated as well.**
+:summary: Here's some summary. **It's formatted as well.**
 
 And the *text*.

--- a/documentation/test_python/page/pages.html
+++ b/documentation/test_python/page/pages.html
@@ -21,7 +21,7 @@
       <div class="m-col-l-10 m-push-l-1">
         <h1>Pages</h1>
         <ul class="m-doc">
-          <li><a href="another.html" class="m-doc">Another page</a> <span class="m-doc">Here's some summary. <strong>It's formated as well.</strong></span></li>
+          <li><a href="another.html" class="m-doc">Another page</a> <span class="m-doc">Here's some summary. <strong>It's formatted as well.</strong></span></li>
           <li><a href="error.html" class="m-doc">error.rst</a> <span class="m-doc"></span></li>
         </ul>
         <script>

--- a/pelican-theme/test/test_blog.py
+++ b/pelican-theme/test/test_blog.py
@@ -173,7 +173,7 @@ class Pagination(BlogTestCase):
         })
 
         # Test the category pages as well (same as author/tag). Couldn't test
-        # that in the above test case because of the overriden pagination
+        # that in the above test case because of the overridden pagination
         # patterns.
         self.assertEqual(*self.actual_expected_contents('category-misc.html'))
         self.assertEqual(*self.actual_expected_contents('category-misc2.html'))

--- a/plugins/m/images.py
+++ b/plugins/m/images.py
@@ -72,7 +72,7 @@ class Image(Directive):
                    'class': directives.class_option,
                    'target': directives.unchanged_required}
 
-    # Overriden by Figure
+    # Overridden by Figure
     image_class = 'm-image'
 
     def run(self):

--- a/plugins/m/sphinx.py
+++ b/plugins/m/sphinx.py
@@ -538,7 +538,7 @@ def merge_inventories(name_map, **kwargs):
             # py:attribute, so that's probably it
             type_string = 'py:attribute'
         elif entry.type == EntryType.ENUM:
-            type_string = 'py:enum' # this desn't exist in Sphinx
+            type_string = 'py:enum' # this doesn't exist in Sphinx
         elif entry.type == EntryType.ENUM_VALUE:
             type_string = 'py:enumvalue' # these don't exist in Sphinx
         elif entry.type == EntryType.DATA:

--- a/plugins/m/test/code/page.html
+++ b/plugins/m/test/code/page.html
@@ -180,7 +180,7 @@ swatch after --- and for inline as well: <code class="m-code"><span class="nt">p
 <pre class="m-code"><span class="nt">p</span> <span class="p">{</span>
     <span class="k">color</span><span class="p">:</span> <span class="mh">#ff3366<span class="m-code-color" style="background-color: #ff3366;"></span></span><span class="p">;</span>
 <span class="p">}</span></pre>
-<p>Applied explicity and then by default --- and for inline as well:
+<p>Applied explicitly and then by default --- and for inline as well:
 <code class="css-filtered m-code"><span class="nt">p</span> <span class="p">{</span> <span class="k">color</span><span class="p">:</span> <span class="mh">#3bd267<span class="m-code-color" style="background-color: #3bd267;"></span></span><span class="p">;</span> <span class="p">}</span></code></p>
 <pre class="m-code"><span class="nt">p</span> <span class="p">{</span>
     <span class="k">color</span><span class="p">:</span> <span class="mh">#3bd267<span class="m-code-color" style="background-color: #3bd267;"></span></span><span class="p">;</span>

--- a/plugins/m/test/code/page.rst
+++ b/plugins/m/test/code/page.rst
@@ -121,7 +121,7 @@ swatch after --- and for inline as well: :css:`p{ color:#ff3366; }`
     :language: css
     :filters: lowercase replace_colors
 
-Applied explicity and then by default --- and for inline as well:
+Applied explicitly and then by default --- and for inline as well:
 :css-filtered:`P{ COLOR:#C0FFEE; }`
 
 .. code:: css


### PR DESCRIPTION
Found via `codespell -q 3 -L nd,te`

ref: https://github.com/zrythm/zrythm/pull/8