### PR TITLE
documentation: Use https links instead of git links.

### DIFF
--- a/doc/documentation/doxygen.rst
+++ b/doc/documentation/doxygen.rst
@@ -85,7 +85,7 @@ into the ``documentation/`` directory:
 
 .. code:: sh
 
-    git clone git://github.com/mosra/m.css
+    git clone https://github.com/mosra/m.css
     cd m.css/documentation
 
 The script requires Python 3.6, depends on `Jinja2 <http://jinja.pocoo.org/>`_

--- a/doc/documentation/python.rst
+++ b/doc/documentation/python.rst
@@ -80,7 +80,7 @@ into the ``documentation/`` directory:
 
 .. code:: sh
 
-    git clone git://github.com/mosra/m.css
+    git clone https://github.com/mosra/m.css
     cd m.css/documentation
 
 The script requires Python 3.6 and depends on `Jinja2 <http://jinja.pocoo.org/>`_

--- a/doc/themes/pelican.rst
+++ b/doc/themes/pelican.rst
@@ -136,7 +136,7 @@ example as a submodule:
 
 .. code:: sh
 
-    git submodule add git://github.com/mosra/m.css
+    git submodule add https://github.com/mosra/m.css
 
 The most minimal configuration to use the theme is the following. Basically you
 need to tell Pelican where the theme resides (it's in the ``pelican-theme/``


### PR DESCRIPTION
GitHub no longer supports git:// links. Trying to
following the clone instructions leads to an error:
>  The unauthenticated git protocol on port 9418 is no longer supported.
> Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.