### PR TITLE
pelican-theme: allow hiding the navbar brand on landing pages without a cover.

### DIFF
--- a/doc/themes/pelican.rst
+++ b/doc/themes/pelican.rst
@@ -7,6 +7,7 @@
     Copyright © 2017 gotchafr <gotchafr@users.noreply.github.com>
     Copyright © 2022 luz paz <luzpaz@pm.me>
     Copyright © 2022 Varun Gandhi <git@cutcul.us>
+    Copyright © 2024 Guillaume Jacquemin <williamjcm@users.noreply.github.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -484,9 +485,9 @@ Example usage:
 ----------------
 
 It's possible to override the default 10-column behavior for pages to make a
-`landing page <{filename}/css/page-layout.rst#landing-pages>`__ with large
-cover image spanning the whole window width. Put cover image URL into a
-:rst:`:cover:` field, the :rst:`:landing:` field then contains
+`landing page <{filename}/css/page-layout.rst#landing-pages>`__ with an
+optional large cover image spanning the whole window width. Put a cover image
+URL into a :rst:`:cover:` field, the :rst:`:landing:` field then contains
 :abbr:`reST <reStructuredText>`-processed content that appears on top of the
 cover image. Contents of the :rst:`:landing:` are put into a
 :html:`<div class="m-container">`, you are expected to fully take care of rows

--- a/pelican-theme/templates/base.html
+++ b/pelican-theme/templates/base.html
@@ -43,10 +43,10 @@
   {% endif %}
 </head>
 <body>
-<header><nav id="navigation"{% if page and page.landing and page.cover %} class="m-navbar-landing"{% elif (page and page.cover) or (article and article.cover) %} class="m-navbar-cover"{% endif %}>
+<header><nav id="navigation"{% if page and page.landing %} class="m-navbar-landing"{% elif (page and page.cover) or (article and article.cover) %} class="m-navbar-cover"{% endif %}>
   <div class="m-container">
     <div class="m-row">
-      <a href="{{ SITEURL }}/" id="m-navbar-brand" class="m-col-t-9 m-col-m-none m-left-m{% if page and page.landing and page.cover and page.hide_navbar_brand == 'True' %} m-navbar-brand-hidden{% endif %}">
+      <a href="{{ SITEURL }}/" id="m-navbar-brand" class="m-col-t-9 m-col-m-none m-left-m{% if page and page.landing and page.hide_navbar_brand == 'True' %} m-navbar-brand-hidden{% endif %}">
         {%- if M_SITE_LOGO %}<img src="{{ M_SITE_LOGO|format_siteurl|e }}" alt="" />{% endif -%}
         {{- (M_SITE_LOGO_TEXT or SITENAME)|e -}}
       </a>

--- a/pelican-theme/test/page_landing/hide-navbar-brand-no-cover.html
+++ b/pelican-theme/test/page_landing/hide-navbar-brand-no-cover.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en" prefix="og: http://ogp.me/ns#">
+<head>
+  <meta charset="UTF-8" />
+  <title>A page | A Pelican Blog</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i" />
+  <link rel="stylesheet" href="static/m-dark.css" />
+  <link rel="canonical" href="hide-navbar-brand-no-cover.html" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta property="og:site_name" content="A Pelican Blog" />
+  <meta property="og:title" content="A page" />
+  <meta name="twitter:title" content="A page" />
+  <meta property="og:url" content="hide-navbar-brand-no-cover.html" />
+  <meta property="og:description" content="Page text." />
+  <meta name="twitter:description" content="Page text." />
+  <meta name="twitter:card" content="summary" />
+  <meta property="og:type" content="page" />
+</head>
+<body>
+<header><nav id="navigation" class="m-navbar-landing">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="./" id="m-navbar-brand" class="m-col-t-9 m-col-m-none m-left-m m-navbar-brand-hidden">A Pelican Blog</a>
+    </div>
+  </div>
+</nav></header>
+<main>
+<article>
+  <div id="m-landing-image">
+    <div id="m-landing-cover">
+      <div class="m-container">
+<!-- landing -->
+<div class="m-row">
+<div class="m-col-m-6 m-push-m-3">
+Landing text.</div>
+</div>
+<!-- /landing -->
+      </div>
+    </div>
+  </div>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+<!-- content -->
+<p>Page text.</p>
+<!-- /content -->
+      </div>
+    </div>
+  </div>
+</article>
+</main>
+</body>
+</html>

--- a/pelican-theme/test/page_landing/hide-navbar-brand-no-cover.rst
+++ b/pelican-theme/test/page_landing/hide-navbar-brand-no-cover.rst
@@ -1,0 +1,12 @@
+A page
+######
+
+:hide_navbar_brand: True
+:landing:
+    .. container:: m-row
+
+        .. container:: m-col-m-6 m-push-m-3
+
+            Landing text.
+
+Page text.

--- a/pelican-theme/test/test_page.py
+++ b/pelican-theme/test/test_page.py
@@ -4,6 +4,7 @@
 #   Copyright © 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024
 #             Vladimír Vondruš <mosra@centrum.cz>
 #   Copyright © 2022 Lukas Pirl <git@lukas-pirl.de>
+#   Copyright © 2024 Guillaume Jacquemin <williamjcm@users.noreply.github.com>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -108,9 +109,10 @@ class Landing(PageTestCase):
 
         # The landing field should have the links expanded, header should not
         # be shown, footer should be. Navbar brand should be hidden in the
-        # second case.
+        # second and third cases.
         self.assertEqual(*self.actual_expected_contents('page.html'))
         self.assertEqual(*self.actual_expected_contents('hide-navbar-brand.html'))
+        self.assertEqual(*self.actual_expected_contents('hide-navbar-brand-no-cover.html'))
 
 class Cover(PageTestCase):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This has the side effect of allowing landing pages in general to not have a cover, which has been reflected in the theme's docs.