### PR TITLE
Add (failing) pybind tests for `os.PathLike` args

### DIFF
--- a/documentation/test_python/pybind_signatures/pybind_signatures.cpp
+++ b/documentation/test_python/pybind_signatures/pybind_signatures.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h> /* needed for std::vector! */
 #include <pybind11/functional.h> /* for std::function */
+#include <pybind11/stl/filesystem.h> /* for std::filesystem::path */
 
 namespace py = pybind11;
 
@@ -25,6 +26,11 @@ bool overloaded(float) { return {}; }
 // Doesn't work with just a plain function pointer, MEH
 void takesAFunction(std::function<int(float, std::vector<float>&)>) {}
 void takesAFunctionReturningVoid(std::function<void()>) {}
+
+// Function demonstrating std::filesystem::path
+std::string demonstratePathArg(const std::filesystem::path& input_path) {
+    return input_path.filename().string();  // Returns the filename portion of the path
+}
 
 struct MyClass {
     static MyClass staticFunction(int, float) { return {}; }
@@ -97,7 +103,8 @@ takes just 3 instead.)")
 This overload, however, takes just a 32-bit (or 64-bit) floating point value of
 3. full_docstring_overloaded(a: int, b: int)
 takes just 2. There's nothing for 4. full_docstring_overloaded(a: poo, b: foo)
-could be another, but it's not added yet.)");
+could be another, but it's not added yet.)")
+        .def("demonstratePathArg", &demonstratePathArg, "Process a std::filesystem::path and return the filename portion");
 
     py::class_<MyClass>(m, "MyClass", "My fun class!")
         .def_static("static_function", &MyClass::staticFunction, "Static method with positional-only args")

--- a/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind22.pyi
+++ b/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind22.pyi
@@ -1,3 +1,4 @@
+import os
 import typing
 
 class MyClass:
@@ -58,6 +59,9 @@ def full_docstring_overloaded(arg0: int, arg1: int, /) -> None:
 
 @typing.overload
 def full_docstring_overloaded(arg0: float, arg1: float, /) -> None:
+    ...
+
+def demonstratePathArg(input_path: os.PathLike, /) -> None:
     ...
 
 @typing.overload

--- a/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind25.pyi
+++ b/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind25.pyi
@@ -1,3 +1,4 @@
+import os
 import typing
 
 class MyClass:
@@ -72,6 +73,9 @@ def full_docstring_overloaded(arg0: int, arg1: int, /) -> None:
 
 @typing.overload
 def full_docstring_overloaded(arg0: float, arg1: float, /) -> None:
+    ...
+
+def demonstratePathArg(input_path: os.PathLike, /) -> None:
     ...
 
 @typing.overload

--- a/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__.pyi
+++ b/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__.pyi
@@ -1,3 +1,4 @@
+import os
 import typing
 
 class MyClass:
@@ -84,6 +85,9 @@ def full_docstring_overloaded(arg0: int, arg1: int, /) -> None:
 
 @typing.overload
 def full_docstring_overloaded(arg0: float, arg1: float, /) -> None:
+    ...
+
+def demonstratePathArg(input_path: os.PathLike, /) -> None:
     ...
 
 @typing.overload


### PR DESCRIPTION
Note: This pull request does not pass the CI pipeline. 

The required import `#include <pybind11/stl/filesystem.h>` wasn't introduced until sometime around Pybind11 v2.11, and thus can't be included with all versions of pybind used in the tests. I'm not sure what the best approach is to conditionally include these tests, depending on the available pybind11 version.

Related to #255.