### PR TITLE
Fix pybind `std::filesystem::path` -> `os.PathLike` mapping, tests

### DIFF
--- a/documentation/python.py
+++ b/documentation/python.py
@@ -928,13 +928,16 @@ def add_module_dependency_for(state: State, object: Union[Any, str]):
         if name_candidate in state.name_map:
             module_name = enclosing_module_for(state, name_candidate)
 
-    # If the above didn't succeed, try other options
+    # If the above didn't succeed, try other options.
     if not module_name:
         if object == 'os.PathLike':
             module_name = 'os'
 
+        elif object == 'pathlib.Path':
+            module_name = 'pathlib'
+
         # If it's a string, assume it's a parsed module_name that's already in the
-        # module_name map, find the leaf module module_name and add it
+        # module_name map, find the leaf module module_name and add it.
         elif isinstance(object, str):
             # We should get string names only for pybind11 types, nothing else
             # TODO er wait, what about unknown annotations? those probably

--- a/documentation/python.py
+++ b/documentation/python.py
@@ -932,8 +932,9 @@ def add_module_dependency_for(state: State, object: Union[Any, str]):
             # no dependency. Given that str is passed only from pybind, all
             # referenced names should be either builtin or known.
             if not name:
-                assert '.' not in object
-                return
+                if '.' not in object or object == 'os.PathLike':
+                    return
+                raise ValueError("Unknown type {} in module {}".format(object, state.current_module))
 
         # If it's directly a module (such as `typing` or `enum` passed from
         # certain parts of the codebase), apply name mapping to it
@@ -1985,6 +1986,8 @@ def extract_function_doc(state: State, parent, entry: Empty) -> List[Any]:
                     # TODO use param.type_relative if it ever exists again in
                     #   addition to param.type_quoted
                     result.params += ['{}: {}'.format(param.name, make_relative_name(state, entry.path, param.type)) if param.type else param.name]
+            # Filter null values out. Not sure where they come from.
+            result.params = [i for i in result.params if i is not None]
             state.search += [result]
 
     return overloads

--- a/documentation/test_python/pybind_signatures/pybind_signatures.MyClass29.html
+++ b/documentation/test_python/pybind_signatures/pybind_signatures.MyClass29.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>pybind_signatures.MyClass29 | My Python Project</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i%7CSource+Code+Pro:400,400i,600" />
+  <link rel="stylesheet" href="m-dark+documentation.compiled.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<header><nav id="navigation">
+  <div class="m-container">
+    <div class="m-row">
+      <a href="index.html" id="m-navbar-brand" class="m-col-t-8 m-col-m-none m-left-m">My Python Project</a>
+    </div>
+  </div>
+</nav></header>
+<main><article>
+  <div class="m-container m-container-inflatable">
+    <div class="m-row">
+      <div class="m-col-l-10 m-push-l-1">
+        <h1>
+          <span class="m-breadcrumb"><a href="pybind_signatures.html">pybind_signatures</a>.<wbr/></span>MyClass29 <span class="m-thin">class</span>
+        </h1>
+        <p>Testing pybind 2.9 features</p>
+        <nav class="m-block m-default">
+          <h3>Contents</h3>
+          <ul>
+            <li>
+              Reference
+              <ul>
+                <li><a href="#staticmethods">Static methods</a></li>
+                <li><a href="#data">Data</a></li>
+              </ul>
+            </li>
+          </ul>
+        </nav>
+        <section id="staticmethods">
+          <h2><a href="#staticmethods">Static methods</a></h2>
+          <dl class="m-doc">
+            <dt id="demonstrate_path_arg">
+              <span class="m-doc-wrap-bumper">def <a href="#demonstrate_path_arg" class="m-doc-self">demonstrate_path_arg</a>(</span><span class="m-doc-wrap">arg0: os.PathLike<span class="m-text m-dim">, /</span>) -&gt; str</span>
+            </dt>
+            <dd>Process a std::filesystem::path and return the filename portion</dd>
+            <dt id="demonstrate_path_return">
+              <span class="m-doc-wrap-bumper">def <a href="#demonstrate_path_return" class="m-doc-self">demonstrate_path_return</a>(</span><span class="m-doc-wrap">arg0: str,
+              arg1: str<span class="m-text m-dim">, /</span>) -&gt; os.PathLike</span>
+            </dt>
+            <dd>Combine two strings into a std::filesystem::path and return it</dd>
+          </dl>
+        </section>
+        <section id="data">
+          <h2><a href="#data">Data</a></h2>
+          <dl class="m-doc">
+            <dt id="is_pybind29">
+              <a href="#is_pybind29" class="m-doc-self">is_pybind29</a> = True
+            </dt>
+            <dd></dd>
+          </dl>
+        </section>
+      </div>
+    </div>
+  </div>
+</article></main>
+</body>
+</html>

--- a/documentation/test_python/pybind_signatures/pybind_signatures.cpp
+++ b/documentation/test_python/pybind_signatures/pybind_signatures.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h> /* needed for std::vector! */
 #include <pybind11/functional.h> /* for std::function */
+#include <pybind11/stl/filesystem.h> /* for std::filesystem::path */
 
 namespace py = pybind11;
 
@@ -25,6 +26,11 @@ bool overloaded(float) { return {}; }
 // Doesn't work with just a plain function pointer, MEH
 void takesAFunction(std::function<int(float, std::vector<float>&)>) {}
 void takesAFunctionReturningVoid(std::function<void()>) {}
+
+// Function demonstrating std::filesystem::path
+std::string demonstrate_path_arg(const std::filesystem::path& input_path) {
+    return input_path.filename().string();  // Returns the filename portion of the path
+}
 
 struct MyClass {
     static MyClass staticFunction(int, float) { return {}; }
@@ -97,7 +103,8 @@ takes just 3 instead.)")
 This overload, however, takes just a 32-bit (or 64-bit) floating point value of
 3. full_docstring_overloaded(a: int, b: int)
 takes just 2. There's nothing for 4. full_docstring_overloaded(a: poo, b: foo)
-could be another, but it's not added yet.)");
+could be another, but it's not added yet.)")
+        .def("demonstrate_path_arg", &demonstrate_path_arg, "Process a std::filesystem::path and return the filename portion");
 
     py::class_<MyClass>(m, "MyClass", "My fun class!")
         .def_static("static_function", &MyClass::staticFunction, "Static method with positional-only args")

--- a/documentation/test_python/pybind_signatures/pybind_signatures.html
+++ b/documentation/test_python/pybind_signatures/pybind_signatures.html
@@ -65,6 +65,10 @@
               <span class="m-doc-wrap-bumper">def <a href="#default_unrepresentable_argument" class="m-doc-self">default_unrepresentable_argument</a>(</span><span class="m-doc-wrap">a: <a href="pybind_signatures.MyClass.html" class="m-doc">MyClass</a> = ...) -&gt; None</span>
             </dt>
             <dd>A function with an unrepresentable default argument</dd>
+            <dt id="demonstrate_path_arg">
+              <span class="m-doc-wrap-bumper">def <a href="#demonstrate_path_arg" class="m-doc-self">demonstrate_path_arg</a>(</span><span class="m-doc-wrap">arg0: os.PathLike<span class="m-text m-dim">, /</span>) -&gt; str</span>
+            </dt>
+            <dd>Process a std::filesystem::path and return the filename portion</dd>
             <dt id="duck">
               <span class="m-doc-wrap-bumper">def <a href="#duck" class="m-doc-self">duck</a>(</span><span class="m-doc-wrap">*args, **kwargs) -&gt; None</span>
             </dt>

--- a/documentation/test_python/pybind_signatures/pybind_signatures.html
+++ b/documentation/test_python/pybind_signatures/pybind_signatures.html
@@ -52,6 +52,8 @@
             <dd>Testing pybind 2.3 features</dd>
             <dt>class <a href="pybind_signatures.MyClass26.html" class="m-doc">MyClass26</a></dt>
             <dd>Testing pybind 2.6 features</dd>
+            <dt>class <a href="pybind_signatures.MyClass29.html" class="m-doc">MyClass29</a></dt>
+            <dd>Testing pybind 2.9 features</dd>
           </dl>
         </section>
         <section id="functions">
@@ -65,10 +67,6 @@
               <span class="m-doc-wrap-bumper">def <a href="#default_unrepresentable_argument" class="m-doc-self">default_unrepresentable_argument</a>(</span><span class="m-doc-wrap">a: <a href="pybind_signatures.MyClass.html" class="m-doc">MyClass</a> = ...) -&gt; None</span>
             </dt>
             <dd>A function with an unrepresentable default argument</dd>
-            <dt id="demonstrate_path_arg">
-              <span class="m-doc-wrap-bumper">def <a href="#demonstrate_path_arg" class="m-doc-self">demonstrate_path_arg</a>(</span><span class="m-doc-wrap">arg0: os.PathLike<span class="m-text m-dim">, /</span>) -&gt; str</span>
-            </dt>
-            <dd>Process a std::filesystem::path and return the filename portion</dd>
             <dt id="duck">
               <span class="m-doc-wrap-bumper">def <a href="#duck" class="m-doc-self">duck</a>(</span><span class="m-doc-wrap">*args, **kwargs) -&gt; None</span>
             </dt>

--- a/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind22.pyi
+++ b/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind22.pyi
@@ -1,3 +1,4 @@
+import os
 import typing
 
 class MyClass:
@@ -38,6 +39,9 @@ def crazy_signature(*args):
     ...
 
 def default_unrepresentable_argument(a: MyClass = ...) -> None:
+    ...
+
+def demonstrate_path_arg(arg0: os.PathLike, /) -> str:
     ...
 
 def duck(*args, **kwargs) -> None:

--- a/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind22.pyi
+++ b/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind22.pyi
@@ -1,4 +1,3 @@
-import os
 import typing
 
 class MyClass:
@@ -35,13 +34,13 @@ class MyClass23:
 class MyClass26:
     is_pybind26 = False
 
+class MyClass29:
+    is_pybind29 = False
+
 def crazy_signature(*args):
     ...
 
 def default_unrepresentable_argument(a: MyClass = ...) -> None:
-    ...
-
-def demonstrate_path_arg(arg0: os.PathLike, /) -> str:
     ...
 
 def duck(*args, **kwargs) -> None:

--- a/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind25.pyi
+++ b/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind25.pyi
@@ -1,3 +1,4 @@
+import os
 import typing
 
 class MyClass:
@@ -52,6 +53,9 @@ def crazy_signature(*args):
     ...
 
 def default_unrepresentable_argument(a: MyClass = ...) -> None:
+    ...
+
+def demonstrate_path_arg(arg0: os.PathLike, /) -> str:
     ...
 
 def duck(*args, **kwargs) -> None:

--- a/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind25.pyi
+++ b/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__-pybind25.pyi
@@ -1,4 +1,3 @@
-import os
 import typing
 
 class MyClass:
@@ -49,13 +48,13 @@ class MyClass23:
 class MyClass26:
     is_pybind26 = False
 
+class MyClass29:
+    is_pybind29 = False
+
 def crazy_signature(*args):
     ...
 
 def default_unrepresentable_argument(a: MyClass = ...) -> None:
-    ...
-
-def demonstrate_path_arg(arg0: os.PathLike, /) -> str:
     ...
 
 def duck(*args, **kwargs) -> None:

--- a/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__.pyi
+++ b/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__.pyi
@@ -1,3 +1,4 @@
+import os
 import typing
 
 class MyClass:
@@ -64,6 +65,9 @@ def crazy_signature(*args):
     ...
 
 def default_unrepresentable_argument(a: MyClass = ...) -> None:
+    ...
+
+def demonstrate_path_arg(arg0: os.PathLike, /) -> str:
     ...
 
 def duck(*args, **kwargs) -> None:

--- a/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__.pyi
+++ b/documentation/test_python/pybind_signatures/stubs/pybind_signatures/__init__.pyi
@@ -61,13 +61,21 @@ class MyClass26:
     def positional_only(a: int, /, b: float) -> int:
         ...
 
+class MyClass29:
+    is_pybind29 = True
+
+    @staticmethod
+    def demonstrate_path_arg(arg0: os.PathLike, /) -> str:
+        ...
+
+    @staticmethod
+    def demonstrate_path_return(arg0: str, arg1: str, /) -> os.PathLike:
+        ...
+
 def crazy_signature(*args):
     ...
 
 def default_unrepresentable_argument(a: MyClass = ...) -> None:
-    ...
-
-def demonstrate_path_arg(arg0: os.PathLike, /) -> str:
     ...
 
 def duck(*args, **kwargs) -> None:

--- a/documentation/test_python/test_pybind.py
+++ b/documentation/test_python/test_pybind.py
@@ -425,6 +425,8 @@ class Signatures(BaseInspectTestCase):
             self.assertEqual(*self.actual_expected_contents('pybind_signatures.MyClass23.html'))
         if pybind_signatures.MyClass26.is_pybind26:
             self.assertEqual(*self.actual_expected_contents('pybind_signatures.MyClass26.html'))
+        if pybind_signatures.MyClass29.is_pybind29:
+            self.assertEqual(*self.actual_expected_contents('pybind_signatures.MyClass29.html'))
 
     def test_stubs(self):
         sys.path.append(self.path)
@@ -437,7 +439,9 @@ class Signatures(BaseInspectTestCase):
         })
 
         # TODO handle writeonly properties correctly
-        if pybind_signatures.MyClass26.is_pybind26:
+        if pybind_signatures.MyClass29.is_pybind29:
+            self.assertEqual(*self.actual_expected_contents('pybind_signatures/__init__.pyi'))
+        elif pybind_signatures.MyClass26.is_pybind26:
             self.assertEqual(*self.actual_expected_contents('pybind_signatures/__init__.pyi'))
         elif pybind_signatures.MyClass23.is_pybind23:
             self.assertEqual(*self.actual_expected_contents('pybind_signatures/__init__.pyi', 'pybind_signatures/__init__-pybind25.pyi'))


### PR DESCRIPTION
Before this fix, an error is raised when a `std::filesystem::path` argument is used with a function. After this fix, it shows correctly in the documentation as a `os.PathLike` argument.

Note: This pull request does not pass the CI pipeline older versions of pybind11. The required `#include <pybind11/stl/filesystem.h>` wasn't introduced until sometime around Pybind11 v2.9, and thus can't be included with all versions of pybind used in the tests. I'm not sure what the best approach is to conditionally include these tests, depending on the available pybind11 version; please advise. 

I'd be happy to split this PR out into the functional changes so those can get merged first without the tests, if necessary.

Replaces separate PRs #255, #257.