### PR TITLE
Nanobind support in the python doc generator

### DIFF
--- a/documentation/test_python/CMakeLists.txt
+++ b/documentation/test_python/CMakeLists.txt
@@ -23,14 +23,29 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(McssDocumentationPybindTests)
 
 find_package(pybind11 CONFIG REQUIRED)
 
+find_package(Python 3.8 COMPONENTS Interpreter Development.Module REQUIRED)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind REQUIRED)
+
 foreach(target pybind_signatures pybind_enums pybind_external_overload_docs pybind_submodules pybind_type_links search_long_suffix_length)
     pybind11_add_module(${target} ${target}/${target}.cpp)
     set_target_properties(${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${target})
+endforeach()
+
+foreach(target signatures)
+    nanobind_add_module(nanobind_${target} pybind_${target}/pybind_${target}.cpp)
+    target_compile_definitions(nanobind_${target} PRIVATE USE_NANOBIND)
+    set_target_properties(nanobind_${target} PROPERTIES
+        OUTPUT_NAME pybind_${target}
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/nanobind_${target})
 endforeach()
 
 # Need a special location for this one

--- a/documentation/test_python/test_nanobind.py
+++ b/documentation/test_python/test_nanobind.py
@@ -1,0 +1,47 @@
+#
+#   This file is part of m.css.
+#
+#   Copyright © 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024
+#             Vladimír Vondruš <mosra@centrum.cz>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+import copy
+import sys
+import unittest
+
+from python import State, parse_pybind_signature, default_config
+
+from . import BaseInspectTestCase
+
+class Signatures(BaseInspectTestCase):
+    def test(self):
+        sys.path.append(self.path)
+        import pybind_signatures
+        self.run_python({
+            # TODO false_positives ???
+            'INPUT_MODULES': [pybind_signatures],
+            'PYBIND11_COMPATIBILITY': True, # TODO don't rely on this
+            'NANOBIND_COMPATIBILITY': True
+        })
+        self.assertEqual(*self.actual_expected_contents('pybind_signatures.html', '../pybind_signatures/pybind_signatures.html'))
+        self.assertEqual(*self.actual_expected_contents('pybind_signatures.MyClass.html', '../pybind_signatures/pybind_signatures.MyClass.html'))
+        # TODO ??
+        # self.assertEqual(*self.actual_expected_contents('false_positives.html'))


### PR DESCRIPTION
Just a rough initial sketch for #261. Quite some things can be reused from pybind11, especially the signature parsing. Other things such as detecting what's an enum or or what's a function have to be redone for nanobind.

Things to do:

- [ ] Make the nanobind tests opt-in so we can still test pybind11 w/ older cmake
- [ ] Nothing should rely on PYBIND11_COMPATIBILITY being enabled
- [ ] Aim for as much test reuse with pybind11 as possible, if the output can be 1:1 it'd be great
  - [ ] Unnamed arguments seem to be named differently (`arg` vs `arg0`?), that may also affect static/class/method distinction
    - [ ] I think I had a stash fixing this for pybind in a better way? Adding real support for classmethods and such. Fix that first
- [ ] Port all tests, not just a subset of one
- [ ] Anything else to do for pybind first, and then just port to nanobind? Enum value docs etc.

Right now I don't think I can find time to finish this, wanted mainly to see how hard it would be -- it seems a manageable scope.